### PR TITLE
Hide network dropdown if no wallet is connected

### DIFF
--- a/components/Nav/Navbar/index.tsx
+++ b/components/Nav/Navbar/index.tsx
@@ -74,7 +74,7 @@ export const NavBarContent = styled(({ className }) => {
 
             {/* DESKTOP */}
             <span className="hidden lg:flex ml-auto">
-                <NetworkDropdown hide={!account} className="relative my-auto mx-4 whitespace-nowrap" />
+                {account ? <NetworkDropdown className="relative my-auto mx-4 whitespace-nowrap" /> : null}
 
                 <AccountDropdown account={account ?? ''} className="my-auto" />
 


### PR DESCRIPTION
# Motivation

If user has not connected their wallet, the network drop down should not show