### PR TITLE
only show balance change on sell form when amount is entered

### DIFF
--- a/archetypes/Exchange/Sell/index.tsx
+++ b/archetypes/Exchange/Sell/index.tsx
@@ -33,7 +33,7 @@ const isInvalidAmount: (
 
     if (minimumTokens.gt(amount)) {
         return {
-            message: `The minimum order size is ${minimumTokens.toFixed()} (${toApproxCurrency(minimumCommitSize)})`,
+            message: `The minimum order size is ${minimumTokens.toFixed(8)} (${toApproxCurrency(minimumCommitSize)})`,
             isInvalid: true,
         };
     }
@@ -135,14 +135,17 @@ export default (() => {
                             {side === SideEnum.long
                                 ? pool.longToken.balance.toFixed(2)
                                 : pool.shortToken.balance.toFixed(2)}{' '}
-                            {'>'}{' '}
-                            {side === SideEnum.long
-                                ? isNaN(amount)
-                                    ? pool.longToken.balance.toFixed(2)
-                                    : (pool.longToken.balance.toNumber() - amount).toFixed(2)
-                                : isNaN(amount)
-                                ? pool.shortToken.balance.toFixed(2)
-                                : (pool.shortToken.balance.toNumber() - amount).toFixed(2)}
+                            {!!amount
+                                ? `> ${
+                                      side === SideEnum.long
+                                          ? isNaN(amount)
+                                              ? pool.longToken.balance.toFixed(2)
+                                              : (pool.longToken.balance.toNumber() - amount).toFixed(2)
+                                          : isNaN(amount)
+                                          ? pool.shortToken.balance.toFixed(2)
+                                          : (pool.shortToken.balance.toNumber() - amount).toFixed(2)
+                                  }`
+                                : null}
                         </>
                     )}
                 </p>


### PR DESCRIPTION
# Motivation 
When burning, the change in balance would show even when the user had not entered an amount to burn
https://www.notion.so/tracerdao/1cf314d3a25d4d228a14d10466d6e33f?v=d40eda4f04894fd0bb7f70bc5829b72d&p=b46ce5b873dd485cb0c6acf799034dc1

# Changes
- Only show the change in balance once an amount has been entered