### PR TITLE
Added pool token modals

### DIFF
--- a/archetypes/Browse/PoolsTable/ClaimModal.tsx
+++ b/archetypes/Browse/PoolsTable/ClaimModal.tsx
@@ -15,8 +15,16 @@ import { swapDefaults, useSwapContext } from '@context/SwapContext';
 export default (({ token, onClick, showModal, setShowModal }) => {
     const hasHoldings = token.myHoldings > 0;
 
-    const { swapState = swapDefaults, swapDispatch } = useSwapContext();
-    const { selectedPool, side, amount, invalidAmount } = swapState;
+    const {
+        swapState = swapDefaults,
+        // swapDispatch
+    } = useSwapContext();
+    const {
+        selectedPool,
+        // side,
+        // invalidAmount
+        amount,
+    } = swapState;
     const pool = usePool(selectedPool);
 
     return (
@@ -35,13 +43,14 @@ export default (({ token, onClick, showModal, setShowModal }) => {
                         className="w-full h-full text-base font-normal "
                         value={amount}
                         onUserInput={(val) => {
-                            // TODO: 
+                            console.log(val);
+                            // TODO:
                             // e.g. swapDispatch({ type: 'setAmount', value: parseFloat(val) });
                         }}
                     />
                     <InnerInputText>
                         {/* TODO: No Tracer Token Label, add one inplace of TSLA */}
-                        <Currency label={"TRC"} ticker={"TSLA"} className="shadow-md" />
+                        <Currency label={'TRC'} ticker={'TSLA'} className="shadow-md" />
                         <div
                             className="m-auto cursor-pointer hover:underline"
                             onClick={(_e) =>
@@ -55,9 +64,9 @@ export default (({ token, onClick, showModal, setShowModal }) => {
                     </InnerInputText>
                 </InputContainer>
                 {/* TODO:  */}
-                <div className={ (false /* invalidAmount.isInvalid */ ? 'text-red-500 ' : '') + 'mt-4 mb-12'}>
-                    { false /* invalidAmount.isInvalid */ &&  ""/* invalidAmount.message */ ? (
-                            ""/* invalidAmount.message */
+                <div className={(false /* invalidAmount.isInvalid */ ? 'text-red-500 ' : '') + 'mt-4 mb-12'}>
+                    {false /* invalidAmount.isInvalid */ && '' /* invalidAmount.message */ ? (
+                        '' /* invalidAmount.message */
                     ) : (
                         <>
                             {/* TODO: this probably isn't correct */}
@@ -78,11 +87,9 @@ export default (({ token, onClick, showModal, setShowModal }) => {
             </Modal>
         </>
     );
-
 }) as React.FC<{
     token: BrowseTableRowData;
-    showModal: Boolean;
-    setShowModal: React.Dispatch<React.SetStateAction<boolean>>
-    ;
+    showModal: boolean;
+    setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
     onClick: () => void;
 }>;

--- a/archetypes/Browse/PoolsTable/index.tsx
+++ b/archetypes/Browse/PoolsTable/index.tsx
@@ -19,7 +19,6 @@ import { usePool } from '@context/PoolContext';
 import { swapDefaults, useSwapContext } from '@context/SwapContext';
 import ClaimModal from './ClaimModal';
 
-
 export default (({ rows }) => {
     const [showModalRebalanceRate, setShowModalRebalanceRate] = useState(false);
     const [showModalStakeToken, setShowModalStakeToken] = useState(false);
@@ -145,7 +144,7 @@ export default (({ rows }) => {
                         token={selectedToken}
                         showModal={showModalStakeToken}
                         setShowModal={setShowModalStakeToken}
-                        onClick={()=>{}}
+                        onClick={() => {}}
                     />
                     <TokenModal
                         title="Unstake Pool Tokens"
@@ -153,16 +152,18 @@ export default (({ rows }) => {
                         token={selectedToken}
                         showModal={showModalUnstakeToken}
                         setShowModal={setShowModalUnstakeToken}
-                        onClick={()=>{}}
+                        onClick={() => {}}
                     />
                     <ClaimModal
                         token={selectedToken}
                         showModal={showModalClaimReward}
                         setShowModal={setShowModalClaimReward}
-                        onClick={()=>{}}
+                        onClick={() => {}}
                     />
                 </>
-            ) : "" }
+            ) : (
+                ''
+            )}
         </>
     );
 }) as React.FC<{
@@ -181,12 +182,20 @@ export default (({ rows }) => {
 //     number: number;
 // }>;
 
-
 const TokenModal = (({ token, title, btnLabel, onClick, showModal, setShowModal }) => {
     const hasHoldings = token.myHoldings > 0;
 
-    const { swapState = swapDefaults, swapDispatch } = useSwapContext();
-    const { selectedPool, side, amount, invalidAmount } = swapState;
+    const {
+        swapState = swapDefaults,
+        // swapDispatch
+    } = useSwapContext();
+    const {
+        selectedPool,
+        // side,
+        amount,
+        // invalidAmount
+    } = swapState;
+
     const pool = usePool(selectedPool);
 
     return (
@@ -205,12 +214,17 @@ const TokenModal = (({ token, title, btnLabel, onClick, showModal, setShowModal 
                         className="w-full h-full text-base font-normal "
                         value={amount}
                         onUserInput={(val) => {
-                            // TODO: 
+                            console.log(val);
+                            // TODO:
                             // e.g. swapDispatch({ type: 'setAmount', value: parseFloat(val) });
                         }}
                     />
                     <InnerInputText>
-                        <Currency label={token.symbol} ticker={tokenSymbolToLogoTicker(token.symbol)} className="shadow-md" />
+                        <Currency
+                            label={token.symbol}
+                            ticker={tokenSymbolToLogoTicker(token.symbol)}
+                            className="shadow-md"
+                        />
                         <div
                             className="m-auto cursor-pointer hover:underline"
                             onClick={(_e) =>
@@ -224,9 +238,9 @@ const TokenModal = (({ token, title, btnLabel, onClick, showModal, setShowModal 
                     </InnerInputText>
                 </InputContainer>
                 {/* TODO:  */}
-                <div className={ (false /* invalidAmount.isInvalid */ ? 'text-red-500 ' : '') + 'mt-4 mb-12'}>
-                    { false /* invalidAmount.isInvalid */ &&  ""/* invalidAmount.message */ ? (
-                            ""/* invalidAmount.message */
+                <div className={(false /* invalidAmount.isInvalid */ ? 'text-red-500 ' : '') + 'mt-4 mb-12'}>
+                    {false /* invalidAmount.isInvalid */ && '' /* invalidAmount.message */ ? (
+                        '' /* invalidAmount.message */
                     ) : (
                         <>
                             {/* TODO: this probably isn't correct */}
@@ -247,13 +261,11 @@ const TokenModal = (({ token, title, btnLabel, onClick, showModal, setShowModal 
             </Modal>
         </>
     );
-
 }) as React.FC<{
     token: BrowseTableRowData;
-    title: String;
-    btnLabel: String;
-    showModal: Boolean;
-    setShowModal: React.Dispatch<React.SetStateAction<boolean>>
-    ;
+    title: string;
+    btnLabel: string;
+    showModal: boolean;
+    setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
     onClick: () => void;
 }>;

--- a/components/General/Currency/index.tsx
+++ b/components/General/Currency/index.tsx
@@ -7,7 +7,7 @@ export const Currency: React.FC<{
     ticker: string;
     label?: string;
 }> = ({ ticker, label, className }) => (
-    <div className={classNames(className ?? '', "flex items-center h-auto p-2 mr-2 rounded-xl bg-white text-gray-500")}>
+    <div className={classNames(className ?? '', 'flex items-center h-auto p-2 mr-2 rounded-xl bg-white text-gray-500')}>
         <Logo className="inline mr-2 m-0 w-5 h-5" ticker={ticker} />
         {label ?? ticker}
     </div>


### PR DESCRIPTION
UI work. Implementation not complete (need someone with more knowledge to complete this). On the `Pool Tokens` page, buttons have been changed to `Stake`, `Unstake` & `Claim` that activate respective modals.

I'm not sure what the implementation is, so I've left some TODOs.

The ClaimModal is a little different to the TokenModal (and I suspect its implementation is different too) so I've put that in its own file.

UI issue, `Stake`, `Unstake` & `Claim`  buttons seem to remain focused (ring/border remains missing) after the modal is closed.