### PR TITLE
[pending commits] fix amount calculation on pending buys

### DIFF
--- a/components/PendingCommits/index.tsx
+++ b/components/PendingCommits/index.tsx
@@ -131,7 +131,7 @@ const BuyRow: React.FC<
             </span>
             <span>{toApproxCurrency(amount)}</span>
             <span>{toApproxCurrency(tokenPrice)}</span>
-            <span>{amount.div(tokenPrice).toNumber()}</span>
+            <span>{amount.div(tokenPrice).toFixed()}</span>
             <span>
                 {nextRebalance.toNumber() - created < frontRunningInterval.toNumber() ? (
                     <TimeLeft targetTime={nextRebalance.toNumber() + updateInterval.toNumber()} />


### PR DESCRIPTION
# Motivation
The amount on the pending buys table was wrong

# Changes
calculate amount using token price