### PR TITLE
[staking] bump TCR price

### DIFF
--- a/archetypes/Stake/FarmsTable/index.tsx
+++ b/archetypes/Stake/FarmsTable/index.tsx
@@ -12,7 +12,7 @@ import { BalancerPoolAsset } from '@libs/types/Staking';
 import { calcBptTokenPrice } from '@libs/utils/calcs';
 
 // TODO: use an actual price
-const TCR_PRICE = new BigNumber('0.10');
+const TCR_PRICE = new BigNumber('0.25');
 
 export default (({ rows, onClickStake, onClickUnstake, onClickClaim, fetchingFarms }) => {
     const [showModal, setShowModal] = useState(false);


### PR DESCRIPTION
# Motivation
The TCR price is outdated. Ideally, this would be a dynamic value which is implemented [here](https://github.com/tracer-protocol/pools-client/pull/191/files) but requires review. This is a safer short-term fix to just get out there ASAP

# Changes
change the hardcoded TCR price of $0.10 to $0.25