### PR TITLE
bump TCR price (#192)

### DIFF
--- a/archetypes/Stake/FarmsTable/index.tsx
+++ b/archetypes/Stake/FarmsTable/index.tsx
@@ -12,7 +12,7 @@ import { BalancerPoolAsset } from '@libs/types/Staking';
 import { calcBptTokenPrice } from '@libs/utils/calcs';
 
 // TODO: use an actual price
-const TCR_PRICE = new BigNumber('0.10');
+const TCR_PRICE = new BigNumber('0.25');
 
 export default (({ rows, onClickStake, onClickUnstake, onClickClaim, fetchingFarms }) => {
     const [showModal, setShowModal] = useState(false);


### PR DESCRIPTION
# Motivation
the staking APR's were inaccurate due to outdated TCR pricing

# Changes
Temp solution to bump hardcoded TCR price, the proper solution is [here](https://github.com/tracer-protocol/pools-client/pull/191) but needs more review 