### PR TITLE
[transaction context] ensure pending count is correct

### DIFF
--- a/context/TransactionContext/index.tsx
+++ b/context/TransactionContext/index.tsx
@@ -63,7 +63,7 @@ export const TransactionStore: React.FC = ({ children }: Children) => {
             },
         );
 
-        setPendingCount(pendingCount + 1);
+        setPendingCount((previousValue) => previousValue + 1);
         const res = callMethod(...params);
 
         res.then(async (contractTransaction) => {
@@ -90,7 +90,7 @@ export const TransactionStore: React.FC = ({ children }: Children) => {
                 autoDismiss: true,
             });
 
-            setPendingCount(pendingCount - 1);
+            setPendingCount((previousValue) => previousValue - 1);
             onSuccess ? onSuccess(contractReceipt) : null;
         }).catch((error) => {
             console.error('Failed transaction', error, error.code);
@@ -111,7 +111,7 @@ export const TransactionStore: React.FC = ({ children }: Children) => {
                     autoDismiss: true,
                 });
             }
-            setPendingCount(pendingCount - 1);
+            setPendingCount((previousValue) => previousValue - 1);
             onError ? onError(error) : null;
         });
     };


### PR DESCRIPTION
# Motivation
The pending count in the transaction context would update based on an outdated value of itself, causing it to decrement below 0. This meant it would work once but then subsequent transactions would not show the pending count properly

# Changes
Use callbacks when setting new `pendingCount` values so that the number being decremented/increment is always the latest accurate value