### PR TITLE
enhanced unsupported network prompts

### DIFF
--- a/components/General/UnsupportedNetworkPopup/index.tsx
+++ b/components/General/UnsupportedNetworkPopup/index.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect } from 'react';
+import { useWeb3 } from '@context/Web3Context/Web3Context';
+import { useArbitrumBridge } from '@context/ArbitrumBridgeContext';
+import { isSupportedNetwork } from '@libs/utils/supportedNetworks';
+import { ARBITRUM } from '@libs/constants';
+import { switchNetworks } from '@libs/utils/rpcMethods';
+import { useToasts } from 'react-toast-notifications';
+import { destinationNetworkLookup } from '@libs/utils/bridge';
+import { networkConfig } from '@context/Web3Context/Web3Context.Config';
+
+const UnsupportedNetwork: React.FC = () => {
+    const errorToastID = React.useRef<string>('');
+    const { account, network, provider } = useWeb3();
+    const { bridgeModalIsOpen } = useArbitrumBridge();
+    const { addToast, updateToast, removeToast } = useToasts();
+
+    // unsupported network popup
+    useEffect(() => {
+        // don't show this while the arb bridge is open
+        if (!bridgeModalIsOpen && !isSupportedNetwork(network) && provider && account) {
+            // ignore if we are already showing the error
+            if (!errorToastID.current) {
+                // @ts-ignore
+                errorToastID.current = addToast(
+                    [
+                        'Unsupported Network',
+                        <span key="unsupported-network-content" className="text-sm">
+                            <a
+                                className="mt-3 underline cursor-pointer hover:opacity-80 text-tracer-400"
+                                onClick={() => {
+                                    switchNetworks(provider, ARBITRUM);
+                                }}
+                            >
+                                Switch to Arbitrum Mainnet
+                            </a>
+                            <br />
+                            <span>New to Arbitrum? </span>
+                            <a
+                                href="https://docs.tracer.finance/tutorials/add-arbitrum-mainnet-to-metamask"
+                                target="_blank"
+                                rel="noreferrer noopner"
+                                className="mt-3 underline cursor-pointer hover:opacity-80 text-tracer-400"
+                            >
+                                Get started
+                            </a>
+                        </span>,
+                    ],
+                    {
+                        appearance: 'error',
+                        autoDismiss: false,
+                        onDismiss: () => {
+                            errorToastID.current = '';
+                        },
+                    },
+                );
+            }
+        } else {
+            if (errorToastID.current) {
+                updateToast(errorToastID.current as unknown as string, {
+                    content: 'Switched Network',
+                    appearance: 'success',
+                    autoDismiss: true,
+                });
+                errorToastID.current = '';
+            }
+        }
+    }, [network, account]);
+
+    // when arb bridge closes, prompt users to switch back to arb if they haven't already
+    useEffect(() => {
+        if (!bridgeModalIsOpen && network) {
+            if (!isSupportedNetwork(network)) {
+                // try take them back to destination network, fall back to arb mainnet
+                const destinationNetworkId = destinationNetworkLookup[network] || ARBITRUM;
+                const destinationNetwork = networkConfig[destinationNetworkId];
+
+                // ignore if we are already showing the error
+                if (destinationNetwork && !errorToastID.current) {
+                    // @ts-ignore
+                    errorToastID.current = addToast(
+                        [
+                            'Switch back to Arbitrum',
+                            <span key="unsupported-network-content" className="text-sm">
+                                Perpetual Pools runs on Arbitrum.{' '}
+                                <a
+                                    className="mt-3 underline cursor-pointer hover:opacity-80 text-tracer-400"
+                                    onClick={() => {
+                                        switchNetworks(provider, destinationNetworkId);
+                                        removeToast(errorToastID.current);
+                                        errorToastID.current = '';
+                                    }}
+                                >
+                                    Switch back to {destinationNetwork.name}.
+                                </a>
+                            </span>,
+                        ],
+                        {
+                            appearance: 'error',
+                            autoDismiss: false,
+                            onDismiss: () => {
+                                errorToastID.current = '';
+                            },
+                        },
+                    );
+                }
+            }
+        }
+    }, [bridgeModalIsOpen]);
+
+    return <></>;
+};
+
+export default UnsupportedNetwork;

--- a/context/PoolContext/poolDispatch.ts
+++ b/context/PoolContext/poolDispatch.ts
@@ -150,35 +150,39 @@ export const reducer: (state: PoolState, action: PoolAction) => PoolState = (sta
                 return state;
             }
         case 'addToPending':
-            const committer = state.pools[action.pool].committer;
-            switch (action.commitType) {
-                case CommitEnum.short_burn:
-                    committer.pendingShort.burn = committer.pendingShort.burn.plus(action.amount);
-                    break;
-                case CommitEnum.short_mint:
-                    committer.pendingShort.mint = committer.pendingShort.mint.plus(action.amount);
-                    break;
-                case CommitEnum.long_burn:
-                    committer.pendingLong.burn = committer.pendingLong.burn.plus(action.amount);
-                    break;
-                case CommitEnum.long_mint:
-                    committer.pendingLong.mint = committer.pendingLong.mint.plus(action.amount);
-                    break;
-                default:
-                    break;
-            }
-            return {
-                ...state,
-                pools: {
-                    ...state.pools,
-                    [action.pool]: {
-                        ...state.pools[action.pool],
-                        committer: {
-                            ...committer,
+            const committer = state.pools[action.pool]?.committer;
+            if (committer) {
+                switch (action.commitType) {
+                    case CommitEnum.short_burn:
+                        committer.pendingShort.burn = committer.pendingShort.burn.plus(action.amount);
+                        break;
+                    case CommitEnum.short_mint:
+                        committer.pendingShort.mint = committer.pendingShort.mint.plus(action.amount);
+                        break;
+                    case CommitEnum.long_burn:
+                        committer.pendingLong.burn = committer.pendingLong.burn.plus(action.amount);
+                        break;
+                    case CommitEnum.long_mint:
+                        committer.pendingLong.mint = committer.pendingLong.mint.plus(action.amount);
+                        break;
+                    default:
+                        break;
+                }
+                return {
+                    ...state,
+                    pools: {
+                        ...state.pools,
+                        [action.pool]: {
+                            ...state.pools[action.pool],
+                            committer: {
+                                ...committer,
+                            },
                         },
                     },
-                },
-            };
+                };
+            } else {
+                return state;
+            }
         case 'setPoolsInitialised':
             return {
                 ...state,

--- a/context/Web3Context/Web3Context.tsx
+++ b/context/Web3Context/Web3Context.tsx
@@ -8,8 +8,6 @@ import { API as OnboardApi, Initialization, Wallet } from '@tracer-protocol/onbo
 import { formatEther } from '@ethersproject/units';
 import { Network, networkConfig } from './Web3Context.Config';
 import { ethers, providers } from 'ethers';
-import { useToasts } from 'react-toast-notifications';
-import { switchNetworks } from '@libs/utils/rpcMethods';
 import { ARBITRUM } from '@libs/constants';
 import { useTheme } from '@context/ThemeContext';
 
@@ -56,8 +54,6 @@ const Web3Store: React.FC<Web3ContextProps> = ({
     cacheWalletSelection = true,
 }) => {
     const { isDark } = useTheme();
-    const errorToastID = React.useRef<string>('');
-    const { addToast, updateToast } = useToasts();
     const [account, setAccount] = useState<string | undefined>(undefined);
     const [signer, setSigner] = useState<ethers.Signer | undefined>(undefined);
     const [network, setNetwork] = useState<number | undefined>(parseInt(ARBITRUM));
@@ -168,54 +164,6 @@ const Web3Store: React.FC<Web3ContextProps> = ({
             mounted = false;
         };
     }, [provider, network]);
-
-    // unsupported network popup
-    useEffect(() => {
-        if (!networkConfig[network ?? -1] && provider && account) {
-            // ignore if we are already showing the error
-            if (!errorToastID.current) {
-                // @ts-ignore
-                errorToastID.current = addToast(
-                    [
-                        'Unsupported Network',
-                        <span key="unsupported-network-content" className="text-sm">
-                            <a
-                                className="mt-3 underline cursor-pointer hover:opacity-80 text-tracer-400"
-                                onClick={() => {
-                                    switchNetworks(provider, ARBITRUM);
-                                }}
-                            >
-                                Switch to Arbitrum Mainnet
-                            </a>
-                            <br />
-                            <span>New to Arbitrum? </span>
-                            <a
-                                href="https://docs.tracer.finance/tutorials/add-arbitrum-mainnet-to-metamask"
-                                target="_blank"
-                                rel="noreferrer noopner"
-                                className="mt-3 underline cursor-pointer hover:opacity-80 text-tracer-400"
-                            >
-                                Get started
-                            </a>
-                        </span>,
-                    ],
-                    {
-                        appearance: 'error',
-                        autoDismiss: false,
-                    },
-                );
-            }
-        } else {
-            if (errorToastID.current) {
-                updateToast(errorToastID.current as unknown as string, {
-                    content: 'Switched Network',
-                    appearance: 'success',
-                    autoDismiss: true,
-                });
-                errorToastID.current = '';
-            }
-        }
-    }, [network, account]);
 
     const checkIsReady = async () => {
         const isReady = await onboard?.walletCheck();

--- a/libs/utils/supportedNetworks.ts
+++ b/libs/utils/supportedNetworks.ts
@@ -1,0 +1,7 @@
+import { ARBITRUM, ARBITRUM_RINKEBY } from '@libs/constants';
+
+export const isSupportedNetwork = (networkId?: number): boolean => {
+    const networkIdString = networkId?.toString();
+
+    return networkIdString === ARBITRUM || networkIdString === ARBITRUM_RINKEBY;
+};

--- a/pages/browse/index.tsx
+++ b/pages/browse/index.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 import PendingCommits from '@components/PendingCommits';
 import { ArbitrumBridge } from '@components/ArbitrumBridge';
 import { ArbitrumBridgeStore } from '@context/ArbitrumBridgeContext';
+import UnsupportedNetworkPopup from '@components/General/UnsupportedNetworkPopup';
 
 export default (() => {
     const router = useRouter();
@@ -23,6 +24,7 @@ export default (() => {
                     <Browse />
                     <PendingCommits />
                     <ArbitrumBridge />
+                    <UnsupportedNetworkPopup />
                 </ArbitrumBridgeStore>
             </PoolStore>
             <Footer />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,7 @@ import { SecurityWidget } from 'vyps-kit';
 import { ArbitrumBridge } from '@components/ArbitrumBridge';
 import { ArbitrumBridgeStore } from '@context/ArbitrumBridgeContext';
 import OnboardTradeModal from '@components/OnboardModal/Trade';
+import UnsupportedNetworkPopup from '@components/General/UnsupportedNetworkPopup';
 
 export default (() => {
     const [showOnboardModal, setShowOnboardModal] = useState(false);
@@ -33,6 +34,7 @@ export default (() => {
                         <Exchange />
                     </SwapStore>
                     <ArbitrumBridge />
+                    <UnsupportedNetworkPopup />
                 </ArbitrumBridgeStore>
             </PoolStore>
             <PendingCommits />

--- a/pages/stakebpt/index.tsx
+++ b/pages/stakebpt/index.tsx
@@ -8,6 +8,7 @@ import PendingCommits from '@components/PendingCommits';
 import { ArbitrumBridge } from '@components/ArbitrumBridge';
 import { ArbitrumBridgeStore } from '@context/ArbitrumBridgeContext';
 import OnboardStakeModal from '@components/OnboardModal/Stake';
+import UnsupportedNetworkPopup from '@components/General/UnsupportedNetworkPopup';
 
 export default (() => {
     const router = useRouter();
@@ -36,6 +37,7 @@ export default (() => {
                     <StakeBPT />
                 </FarmStore>
                 <ArbitrumBridge />
+                <UnsupportedNetworkPopup />
             </ArbitrumBridgeStore>
             <Footer />
             <PendingCommits />

--- a/pages/stakepooltoken/index.tsx
+++ b/pages/stakepooltoken/index.tsx
@@ -8,6 +8,7 @@ import PendingCommits from '@components/PendingCommits';
 import { ArbitrumBridge } from '@components/ArbitrumBridge';
 import { ArbitrumBridgeStore } from '@context/ArbitrumBridgeContext';
 import OnboardStakeModal from '@components/OnboardModal/Stake';
+import UnsupportedNetworkPopup from '@components/General/UnsupportedNetworkPopup';
 
 export default (() => {
     const router = useRouter();
@@ -36,6 +37,7 @@ export default (() => {
                     <StakePool />
                 </FarmStore>
                 <ArbitrumBridge />
+                <UnsupportedNetworkPopup />
             </ArbitrumBridgeStore>
             <Footer />
             <PendingCommits />


### PR DESCRIPTION
# Motivation
It was pretty janky when using the bridge and switching networks, error toasts would show up despite switching networks being required to bridge

# Changes
Move the unsupported network toast into its own component that is aware of the arbitrum bridge modal state, this allows us to prevent showing while the users is in the bridge and allows us to prompt the user to switch back to arbitrum after closing the bridge modal