### PR TITLE
[arb bridge] ensure bridge is always in sync with connected account

### DIFF
--- a/components/ArbitrumBridge/MultiBridge.tsx
+++ b/components/ArbitrumBridge/MultiBridge.tsx
@@ -90,10 +90,10 @@ export const MultiBridge: React.FC<MultiBridgeProps> = (props) => {
     }, [fromNetwork]);
 
     const selectedAssetBalance = useMemo(() => {
-        if (!selectedAsset) {
+        if (!selectedAsset || !account) {
             return null;
         }
-        const assetBalance = bridgeableBalances[fromNetwork?.id]?.[selectedAsset?.symbol];
+        const assetBalance = bridgeableBalances[fromNetwork?.id]?.[account]?.[selectedAsset?.symbol];
         return assetBalance || null;
     }, [selectedAsset, fromNetwork, bridgeableBalances]);
 

--- a/context/ArbitrumBridgeContext/index.tsx
+++ b/context/ArbitrumBridgeContext/index.tsx
@@ -129,7 +129,7 @@ export const ArbitrumBridgeStore: React.FC = ({ children }: Children) => {
         }));
 
         return bridge;
-    }, [fromNetwork, account]);
+    }, [fromNetwork?.id, account]);
 
     const bridgeEth = async (amount: BigNumber, callback: () => void) => {
         if (!handleTransaction) {
@@ -401,10 +401,9 @@ export const ArbitrumBridgeStore: React.FC = ({ children }: Children) => {
             console.error('Failed to refresh bridgeable balance: fromNetwork is unavailable');
         }
 
-        // ensure the top level (network) entry is initialised
-
-        newBridgeableBalances[network] = newBridgeableBalances[network] || {};
-        // if we are bridging a token from L1 -> L2, the spender is the gateway router for the L1 network
+        // ensure the network and account entries are initialised
+        newBridgeableBalances[fromNetwork.id] = newBridgeableBalances[fromNetwork.id] || {};
+        newBridgeableBalances[fromNetwork.id][account] = newBridgeableBalances[fromNetwork.id][account] || {};
 
         try {
             if (asset.symbol === bridgeableTickers.ETH) {
@@ -412,7 +411,7 @@ export const ArbitrumBridgeStore: React.FC = ({ children }: Children) => {
                     ? await bridge?.l2Bridge.getL2EthBalance()
                     : await bridge?.l1Bridge.getL1EthBalance();
 
-                newBridgeableBalances[network][asset.symbol] = {
+                newBridgeableBalances[fromNetwork.id][account][asset.symbol] = {
                     balance: new BigNumber(ethers.utils.formatEther(balance)),
                     allowance: new BigNumber(ethers.utils.formatEther(balance)),
                     spender: '',
@@ -429,7 +428,7 @@ export const ArbitrumBridgeStore: React.FC = ({ children }: Children) => {
                     isL1TokenData(tokenData) ? tokenData.decimals : tokenData.contract.decimals(),
                 ]);
 
-                newBridgeableBalances[network][asset.symbol] = {
+                newBridgeableBalances[fromNetwork.id][account][asset.symbol] = {
                     balance: new BigNumber(ethers.utils.formatUnits(tokenData.balance, decimals)),
                     allowance: new BigNumber(ethers.utils.formatUnits(allowance, decimals)),
                     spender: erc20GatewayAddress,

--- a/context/ThemeContext/index.tsx
+++ b/context/ThemeContext/index.tsx
@@ -34,7 +34,7 @@ export const ThemeStore: React.FC<Children> = ({ children }: Children) => {
     useEffect(() => {
         if (localStorage.getItem('theme') === 'light') {
             setIsDark(false);
-        } 
+        }
     }, []);
 
     return (

--- a/libs/types/General.ts
+++ b/libs/types/General.ts
@@ -134,6 +134,6 @@ export type BridgeableBalance = {
     spender: string; // address that allowance corresponds to
 };
 
-export type BridgeableBalances = { [network: string]: { [symbol: string]: BridgeableBalance } };
+export type BridgeableBalances = { [network: string]: { [account: string]: { [symbol: string]: BridgeableBalance } } };
 
 export type BridgeProviders = { [network: string]: ethers.providers.JsonRpcProvider };

--- a/libs/utils/bridge.ts
+++ b/libs/utils/bridge.ts
@@ -9,10 +9,10 @@ export const destinationNetworkLookup: { [current: number]: string } = {
     [ARBITRUM]: MAINNET,
 };
 
-export const bridgeableTickers = {
+export const bridgeableTickers: { [symbol: string]: LogoTicker } = {
     ETH: 'ETH',
     USDC: 'USDC',
-} as const;
+};
 
 const usdcSharedDetails = {
     name: 'USDC',

--- a/public/scripts/theme.js
+++ b/public/scripts/theme.js
@@ -8,8 +8,8 @@
             html.classList.remove('theme-dark');
         } else {
             // else add theme dark this is default
-            html.classList.add('theme-dark')
-        } 
+            html.classList.add('theme-dark');
+        }
     }
 
     try {


### PR DESCRIPTION
# Motivation
When switching accounts, the asset balances would fall out of sync. This was happening due to the way the `useEffect` was updating the bridge when the selected account changed.

# Changes
- Ensure the bridge is always in the context of the right account by explicitly fetching it just before using it
- Cache bridge instances on a per account/network combo to prevent reinitializing bridge unnecessarily  