### PR TITLE
Remove unlock USDC for burn

### DIFF
--- a/components/General/Button/ExchangeButton.tsx
+++ b/components/General/Button/ExchangeButton.tsx
@@ -31,9 +31,8 @@ const ExchangeButton: React.FC<{ actionType: CommitActionEnum }> = ({ actionType
             );
         }
         if (
-            (!pool.quoteToken.approvedAmount?.gte(pool.quoteToken.balance) 
-            || pool.quoteToken.approvedAmount.eq(0))
-            && (commitAction !== CommitActionEnum.burn)
+            (!pool.quoteToken.approvedAmount?.gte(pool.quoteToken.balance) || pool.quoteToken.approvedAmount.eq(0)) &&
+            commitAction !== CommitActionEnum.burn
         ) {
             return (
                 <>


### PR DESCRIPTION
# Motivation
Users dont need to unlock USDC to burn. Instead it will display a disabled ok let's burn.

# Changes
- add conditional not display unlock on burn page