### PR TITLE
[arb bridge] add warning when bridging less than $1000 USDC

### DIFF
--- a/components/General/Input/index.tsx
+++ b/components/General/Input/index.tsx
@@ -5,11 +5,14 @@ import React from 'react';
 export const InputContainer: React.FC<{
     className?: string;
     error?: boolean;
-}> = ({ error, className = '', children }) => (
+    warning?: boolean;
+}> = ({ error, warning, className = '', children }) => (
     <div
         className={classNames(
             'relative py-3 px-3 border rounded bg-theme-button-bg',
-            error
+            warning
+                ? 'border-yellow-500 text-yellow-600 focus-within:ring-yellow-600'
+                : error
                 ? 'border-red-300 text-red-500 focus-within:ring-red-500'
                 : 'border-theme-border text-theme-text opacity-80 focus-within:ring-theme-primary',
             'focus-within:ring-2 focus-within:ring-opacity-50 ',

--- a/libs/utils/bridge.ts
+++ b/libs/utils/bridge.ts
@@ -1,6 +1,7 @@
 import { ARBITRUM_RINKEBY, ARBITRUM, MAINNET, RINKEBY } from '@libs/constants';
 import { BridgeableAsset } from '@libs/types/General';
 import { LogoTicker } from '@components/General/Logo';
+import BigNumber from 'bignumber.js';
 
 type DestinationNetwork = typeof RINKEBY | typeof ARBITRUM_RINKEBY | typeof MAINNET | typeof ARBITRUM;
 
@@ -35,35 +36,81 @@ export type BridgeableAssets = {
     [networkId: string]: BridgeableAsset[];
 };
 
+type KnownAssetAddressesByNetwork = { [networkId: string]: { [ticker: string]: string } };
+const knownAssetAddressesByNetwork: KnownAssetAddressesByNetwork = {
+    [ARBITRUM]: {
+        [bridgeableTickers.USDC]: '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8',
+    },
+    [ARBITRUM_RINKEBY]: {
+        [bridgeableTickers.USDC]: '0x1E77ad77925Ac0075CF61Fb76bA35D884985019d',
+    },
+    [MAINNET]: {
+        [bridgeableTickers.USDC]: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    },
+    [RINKEBY]: {
+        [bridgeableTickers.USDC]: '0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b',
+    },
+};
+
 export const bridgeableAssets: BridgeableAssets = {
     [ARBITRUM]: [
         {
-            address: '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8',
+            address: knownAssetAddressesByNetwork[ARBITRUM][bridgeableTickers.USDC],
             ...usdcSharedDetails,
         },
         BRIDGEABLE_ASSET_ETH,
     ],
     [ARBITRUM_RINKEBY]: [
         {
-            address: '0x1E77ad77925Ac0075CF61Fb76bA35D884985019d',
+            address: knownAssetAddressesByNetwork[ARBITRUM_RINKEBY][bridgeableTickers.USDC],
             ...usdcSharedDetails,
         },
         BRIDGEABLE_ASSET_ETH,
     ],
     [MAINNET]: [
         {
-            address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            address: knownAssetAddressesByNetwork[MAINNET][bridgeableTickers.USDC],
             ...usdcSharedDetails,
         },
         BRIDGEABLE_ASSET_ETH,
     ],
     [RINKEBY]: [
         {
-            address: '0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b',
+            address: knownAssetAddressesByNetwork[RINKEBY][bridgeableTickers.USDC],
             ...usdcSharedDetails,
         },
         BRIDGEABLE_ASSET_ETH,
     ],
+};
+
+const minUSDCWarning =
+    'Please note that the minimum order size for Perpetual Pools is $1,000 USDC. Ensure that you deposit enough USDC to meet the order size requirement.';
+type BridgeableAssetWarnings = {
+    [networkId: string]: {
+        [ticker: string]: { getWarningText: ({ amount }: { amount: BigNumber }) => string | null };
+    };
+};
+export const bridgeableAssetWarnings: BridgeableAssetWarnings = {
+    [MAINNET]: {
+        [bridgeableTickers.USDC]: {
+            getWarningText: ({ amount }) => {
+                if (amount.lt(1000)) {
+                    return minUSDCWarning;
+                }
+                return null;
+            },
+        },
+    },
+    [RINKEBY]: {
+        [bridgeableTickers.USDC]: {
+            getWarningText: ({ amount }) => {
+                if (amount.lt(1000)) {
+                    return minUSDCWarning;
+                }
+                return null;
+            },
+        },
+    },
 };
 
 export const isArbitrumNetwork = (networkId: string): boolean =>


### PR DESCRIPTION
# Motivation
Users may not be aware of the minimum order size when they use the native arbitrum bridge

# Changes
- Add warning config to bridge utils based on network/asset/amount
- Add warning state to general `Input` component

https://www.notion.so/tracerdao/Add-minimum-order-size-warning-a059d1e442654b9e86d68d06a48bd6bc

![image](https://user-images.githubusercontent.com/14157626/138658589-1482a209-5be0-4c27-9680-4b3fa1d76b9f.png)
