### PR TITLE
Remove listeners if an old subscription picks up an event

### DIFF
--- a/context/PoolContext/index.tsx
+++ b/context/PoolContext/index.tsx
@@ -250,6 +250,7 @@ export const PoolStore: React.FC<Children> = ({ children }: Children) => {
                 PoolCommitter__factory.abi,
                 subscriptionProvider,
             ) as PoolCommitter;
+            provider.removeAllListeners();
 
             // @ts-ignore
             if (!subscriptions.current[committerInfo.address]) {
@@ -306,24 +307,35 @@ export const PoolStore: React.FC<Children> = ({ children }: Children) => {
                         Old price: ${ethers.utils.formatEther(startPrice)}
                         New price: ${ethers.utils.formatEther(endPrice)}
                     `);
-                    const leveragedPool = new ethers.Contract(
-                        pool,
-                        LeveragedPool__factory.abi,
-                        subscriptionProvider,
-                    ) as LeveragedPool;
-                    leveragedPool.lastPriceTimestamp().then((lastUpdate) => {
-                        console.debug(`New last updated: ${lastUpdate}`);
-                        poolsDispatch({
-                            type: 'setLastUpdate',
-                            pool: pool,
-                            value: new BigNumber(lastUpdate.toString()),
+                    if (subscriptionProvider.network.chainId !== provider.network.chainId) {
+                        console.error('Stale upkeep detected: Networks do not match. Removing all listners');
+                        // remove all listeners as we are no longer connected to this network
+                        keeperInstance.removeAllListeners();
+                        // remove from list of subscriptions
+                        subscriptions.current = {
+                            ...subscriptions.current,
+                            [keeper]: false,
+                        };
+                    } else {
+                        const leveragedPool = new ethers.Contract(
+                            pool,
+                            LeveragedPool__factory.abi,
+                            subscriptionProvider,
+                        ) as LeveragedPool;
+                        leveragedPool.lastPriceTimestamp().then((lastUpdate) => {
+                            console.debug(`New last updated: ${lastUpdate}`);
+                            poolsDispatch({
+                                type: 'setLastUpdate',
+                                pool: pool,
+                                value: new BigNumber(lastUpdate.toString()),
+                            });
                         });
-                    });
-                    updateTokenBalances(poolsState.pools[pool], subscriptionProvider);
-                    commitDispatch({
-                        type: 'resetCommits',
-                        pool: pool,
-                    });
+                        updateTokenBalances(poolsState.pools[pool], subscriptionProvider);
+                        commitDispatch({
+                            type: 'resetCommits',
+                            pool: pool,
+                        });
+                    }
                 });
                 subscriptions.current = {
                     ...subscriptions.current,

--- a/context/PoolContext/index.tsx
+++ b/context/PoolContext/index.tsx
@@ -250,7 +250,6 @@ export const PoolStore: React.FC<Children> = ({ children }: Children) => {
                 PoolCommitter__factory.abi,
                 subscriptionProvider,
             ) as PoolCommitter;
-            provider.removeAllListeners();
 
             // @ts-ignore
             if (!subscriptions.current[committerInfo.address]) {

--- a/libs/hooks/useBrowsePools/index.tsx
+++ b/libs/hooks/useBrowsePools/index.tsx
@@ -22,6 +22,7 @@ export default (() => {
                     nextLongBalance,
                     leverage,
                 } = pool;
+
                 const {
                     pendingLong: { burn: pendingLongBurn },
                     pendingShort: { burn: pendingShortBurn },


### PR DESCRIPTION
# Motivation
Moving between networks was causing an application crash when it picked up on old event listeners.

# Changes
- check that the subscription providers network matches the currently selected providers network. If they dont match the remove all the event listeners and dont update the poolsState