### PR TITLE
[balancer spot price] add swapFee to calculations

### DIFF
--- a/libs/utils/rpcMethods.ts
+++ b/libs/utils/rpcMethods.ts
@@ -121,11 +121,12 @@ export const getBalancerPrices: (balancerInfo?: Network['balancerInfo']) => Prom
 
     const data = {
         query: `{
-                leveragedPools: pools(where: { 
+                leveragedPools: pools(where: {
                     address_in: ${JSON.stringify(balancerInfo.leveragedPools)}
                 }) {
                     id
                     address
+                    swapFee
                     tokens {
                         address
                         balance
@@ -134,11 +135,12 @@ export const getBalancerPrices: (balancerInfo?: Network['balancerInfo']) => Prom
                         symbol
                     }
                 },
-                nonLeveragedPools: pools(where: { 
+                nonLeveragedPools: pools(where: {
                     address_in: ${JSON.stringify(balancerInfo.pools)}
                 }) {
                     id
                     address
+                    swapFee
                     tokens {
                         address
                         balance
@@ -152,6 +154,7 @@ export const getBalancerPrices: (balancerInfo?: Network['balancerInfo']) => Prom
                 }) {
                     id
                     address
+                    swapFee
                     tokens {
                         address
                         balance
@@ -178,6 +181,7 @@ export const getBalancerPrices: (balancerInfo?: Network['balancerInfo']) => Prom
         pools: {
             id: string;
             address: string;
+            swapFee: string;
             tokens: {
                 address: string;
                 balance: string;
@@ -205,6 +209,7 @@ export const getBalancerPrices: (balancerInfo?: Network['balancerInfo']) => Prom
                         balance: new BigNumber(token.balance),
                         weight: new BigNumber(token.weight),
                     },
+                    new BigNumber(pool.swapFee),
                 );
             }
         }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "@mycelium-ethereum/vyps-kit": "^0.1.0",
         "@tracer-protocol/onboard": "^2.2.4",
         "@tracer-protocol/perpetual-pools-contracts": "^0.0.4",
-        "@tracer-protocol/tracer-pools-utils": "^0.0.6",
+        "@tracer-protocol/tracer-pools-utils": "^0.0.7",
         "antd": "^4.16.13",
         "arb-ts": "^1.0.0-beta.4",
         "bignumber.js": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3086,10 +3086,10 @@
     solidity-coverage "^0.7.16"
     ts-command-line-args "^2.1.0"
 
-"@tracer-protocol/tracer-pools-utils@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@tracer-protocol/tracer-pools-utils/-/tracer-pools-utils-0.0.6.tgz#45dd18e06591a9202bed4325f8ed056eccca9bd3"
-  integrity sha512-AdTSbyVBQLS3BlL+AnDJ5TY2+t20A27KW3XgEseXfDOgHizNw3zQSfLlzLKENlHtdABDovqhnRTbxEtzdrLn6w==
+"@tracer-protocol/tracer-pools-utils@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@tracer-protocol/tracer-pools-utils/-/tracer-pools-utils-0.0.7.tgz#6581de5c96196f333cea1e2289141557a37af385"
+  integrity sha512-Bl3HkLxnPOnZWkMFhqZC26Xof8FICB82t3VBDjAnShpZkSh3x6X6qxl2GoarYbsfXQLvRBr9FKqkqsXKOHaeBw==
   dependencies:
     bignumber.js "^9.0.1"
 


### PR DESCRIPTION
# Motivation
Balancer spot pricing was slightly off because swap fees were not included in calcs

# Changes
- update `tracer-pools-utils` to latest version
- query swapFee from balancer graph and pass into spot price calc function