### PR TITLE
Add safety for unsupported networks, fix poopup

### DIFF
--- a/components/General/UnsupportedNetworkPopup/index.tsx
+++ b/components/General/UnsupportedNetworkPopup/index.tsx
@@ -17,9 +17,18 @@ const UnsupportedNetwork: React.FC = () => {
     useEffect(() => {
         // don't show this while the arb bridge is open
         const hasDismissedInitialArbModal = localStorage.getItem('showBridgeFunds') === 'true';
-        if (hasDismissedInitialArbModal && !bridgeModalIsOpen && !isSupportedNetwork(network) && provider && account) {
+        console.log('unsupported', hasDismissedInitialArbModal, bridgeModalIsOpen, account);
+        if (
+            hasDismissedInitialArbModal &&
+            !bridgeModalIsOpen &&
+            !isSupportedNetwork(network) &&
+            !!provider &&
+            !!account
+        ) {
+            console.log('in here', unsupportedNetworkPopupRef.current);
             // ignore if we are already showing the error
             if (!unsupportedNetworkPopupRef.current) {
+                console.log('Already showing');
                 // @ts-ignore
                 unsupportedNetworkPopupRef.current = addToast(
                     [
@@ -64,7 +73,7 @@ const UnsupportedNetwork: React.FC = () => {
                 unsupportedNetworkPopupRef.current = '';
             }
         }
-    }, [network, account]);
+    }, [network, account, provider]);
 
     // when arb bridge closes, prompt users to switch back to arb if they haven't already
     useEffect(() => {

--- a/context/PoolContext/index.tsx
+++ b/context/PoolContext/index.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useMemo, useReducer, useRef, useState } from 'react';
-import { Children, Pool } from 'libs/types/General';
+import { Children, Pool, StaticPoolInfo } from 'libs/types/General';
 import { useWeb3 } from '@context/Web3Context/Web3Context';
 import { initialPoolState, reducer } from './poolDispatch';
 import { fetchCommits, fetchTokenApprovals, fetchTokenBalances, initPool } from './helpers';
@@ -66,7 +66,7 @@ export const PoolStore: React.FC<Children> = ({ children }: Children) => {
         console.debug('Attempting to initialise pools');
         if (provider?.network?.chainId) {
             const network = provider.network?.chainId?.toString();
-            const pools = poolList[network as AvailableNetwork];
+            const pools: StaticPoolInfo[] = poolList[network as AvailableNetwork] ?? [];
             console.debug(`Initialising pools ${network.slice()}`, pools);
             poolsDispatch({ type: 'resetPools' });
             hasSetPools.current = false;


### PR DESCRIPTION
# Motivation
- pools list undefined for unsupported networks

# Changes
- ensure unsupported network pops up
- fail safe on pools init