### PR TITLE
Update time taken to withdraw from Arbitrum

### DIFF
--- a/archetypes/Exchange/Buy/index.tsx
+++ b/archetypes/Exchange/Buy/index.tsx
@@ -229,7 +229,7 @@ export default (() => {
                 <div>
                     Deposit funds from Ethereum to Arbitrum to get started with Perpetual Pools. Ensure you deposit{' '}
                     <b>USDC</b> for collateral and <b>ETH</b> for gas. Please note that the withdrawal process from
-                    Arbitrum to Ethereum takes approximately 7 days.
+                    Arbitrum to Ethereum takes approximately 8 days.
                     <br />
                     <br />
                     If you have any questions, please{' '}

--- a/components/ArbitrumBridge/MultiBridge.tsx
+++ b/components/ArbitrumBridge/MultiBridge.tsx
@@ -342,7 +342,7 @@ export const MultiBridge: React.FC<MultiBridgeProps> = (props) => {
                             </span>
                         ) : (
                             <>
-                                <b>Note</b>: Withdrawals from Arbitrum take approximately 7 days to complete. Visit the{' '}
+                                <b>Note</b>: Withdrawals from Arbitrum take approximately 8 days to complete. Visit the{' '}
                                 <a
                                     href="https://bridge.arbitrum.io"
                                     target="_blank"

--- a/context/ArbitrumBridgeContext/index.tsx
+++ b/context/ArbitrumBridgeContext/index.tsx
@@ -66,7 +66,7 @@ const BRIDGEABLE_ASSET_ETH = {
 
 const withdrawalToastBody = (
     <>
-        It will take approximately 7 days to receive your funds on Ethereum. To view pending withdrawals, visit the
+        It will take approximately 8 days to receive your funds on Ethereum. To view pending withdrawals, visit the
         official Arbitrum bridge.
     </>
 );


### PR DESCRIPTION
### Motivation

Show 8 days as the time taken to withdraw ETH/USDC from Arbitrum just as Arbitrum bridge displays.