### PR TITLE
add `rewardsEnded` staking farm config option, apply to EUR pools

### DIFF
--- a/archetypes/Stake/FarmsTable/index.tsx
+++ b/archetypes/Stake/FarmsTable/index.tsx
@@ -10,7 +10,7 @@ import { Logo, LogoTicker, tokenSymbolToLogoTicker } from '@components/General/L
 import Loading from '@components/General/Loading';
 import { BalancerPoolAsset } from '@libs/types/Staking';
 import { calcAPY, calcBptTokenPrice } from '@tracer-protocol/tracer-pools-utils';
-import { APYTip } from '@components/Tooltips';
+import { APYTip, RewardsEndedTip } from '@components/Tooltips';
 
 export default (({ rows, onClickStake, onClickUnstake, onClickClaim, fetchingFarms, tcrUSDCPrice }) => {
     const [showModal, setShowModal] = useState(false);
@@ -142,7 +142,13 @@ const PoolRow: React.FC<{
                     )}
                 </div>
             </TableRowCell>
-            <TableRowCell>{`${apy.times(100).toFixed(2)}% / ${apr.times(100).toFixed(2)}%`}</TableRowCell>
+            <TableRowCell>
+                {farm.rewardsEnded ? (
+                    <RewardsEndedTip>N/A</RewardsEndedTip>
+                ) : (
+                    `${apy.times(100).toFixed(2)}% / ${apr.times(100).toFixed(2)}%`
+                )}
+            </TableRowCell>
             <TableRowCell>
                 <TableRowCell>{toApproxCurrency(tokenPrice.times(farm.totalStaked))}</TableRowCell>
             </TableRowCell>
@@ -159,7 +165,7 @@ const PoolRow: React.FC<{
             </TableRowCell>
             <TableRowCell>
                 <Button
-                    disabled={farm.stakingTokenBalance.eq(0)}
+                    disabled={farm.rewardsEnded || farm.stakingTokenBalance.eq(0)}
                     className="mx-1 w-[78px] rounded-2xl font-bold uppercase "
                     size="sm"
                     variant="primary-light"

--- a/archetypes/Stake/StakeGeneric/index.tsx
+++ b/archetypes/Stake/StakeGeneric/index.tsx
@@ -87,6 +87,7 @@ export default (({
             poolDetails: farm.poolDetails,
             link: farm.link,
             linkText: farm.linkText,
+            rewardsEnded: farm.rewardsEnded,
         };
     });
 

--- a/components/Tooltips/index.tsx
+++ b/components/Tooltips/index.tsx
@@ -20,6 +20,11 @@ export const APYTip: React.FC = ({ children }) => {
     return <StyledTooltip title={Content}>{children}</StyledTooltip>;
 };
 
+export const RewardsEndedTip: React.FC = ({ children }) => {
+    const Content = 'Staking rewards have ended for this pool';
+    return <StyledTooltip title={Content}>{children}</StyledTooltip>;
+};
+
 export const LockTip: React.FC = ({ children }) => {
     const Content = (
         <>

--- a/components/Tooltips/index.tsx
+++ b/components/Tooltips/index.tsx
@@ -21,7 +21,7 @@ export const APYTip: React.FC = ({ children }) => {
 };
 
 export const RewardsEndedTip: React.FC = ({ children }) => {
-    const Content = 'Staking rewards have ended for this pool';
+    const Content = 'Staking rewards have ended for this pool.';
     return <StyledTooltip title={Content}>{children}</StyledTooltip>;
 };
 

--- a/context/Web3Context/Web3Context.Config.ts
+++ b/context/Web3Context/Web3Context.Config.ts
@@ -15,6 +15,7 @@ type Farm = {
     balancerPoolId?: string;
     link?: string;
     linkText?: string;
+    rewardsEnded?: boolean;
 };
 
 export type AvailableNetwork =
@@ -173,21 +174,25 @@ export const networkConfig: Record<AvailableNetwork, Network> = {
                 address: '0x39723F758701E82D5Fbe8b3Bfd1a646d73f99793', // 1-EUR/USDC-long
                 pool: '0x2C740EEe739098Ab8E90f5Af78ac1d07835d225B',
                 abi: StakingRewards__factory.abi,
+                rewardsEnded: true,
             },
             {
                 address: '0x2E7584FCd6f909BFa7A21aEb1a4894674C16e4Cd', // 1-EUR/USDC-short
                 pool: '0x2C740EEe739098Ab8E90f5Af78ac1d07835d225B',
                 abi: StakingRewards__factory.abi,
+                rewardsEnded: true,
             },
             {
                 address: '0x44b42E7ef481F6d1ff8d0fd7BFF6b3C8bD25a581', // 3-EUR/USDC-long
                 pool: '0xA45B53547EC002403531D453c118AC41c03B3346',
                 abi: StakingRewards__factory.abi,
+                rewardsEnded: true,
             },
             {
                 address: '0x0450959a393c3D6E6E37b65A6e836F59C47E24D0', // 3-EUR/USDC-short
                 pool: '0xA45B53547EC002403531D453c118AC41c03B3346',
                 abi: StakingRewards__factory.abi,
+                rewardsEnded: true,
             },
         ],
         bptFarms: [

--- a/libs/types/Staking.ts
+++ b/libs/types/Staking.ts
@@ -19,6 +19,7 @@ export type FarmTableDetails = {
     stakingTokenBalance: BigNumber;
     stakingTokenSupply: BigNumber;
     rewardsPerYear: BigNumber;
+    rewardsEnded: boolean;
     link?: string;
     linkText?: string;
     bptDetails?: {


### PR DESCRIPTION
# Motivation
the staking rewards have ended but the UI implies they are still active

# Changes
add `rewardsEnded` attribute to pools farm config and use it on the EUR/USD pools 