### PR TITLE
Add styled components themes

### DIFF
--- a/archetypes/BalancerBuySell/index.tsx
+++ b/archetypes/BalancerBuySell/index.tsx
@@ -9,7 +9,7 @@ import TWButtonGroup from '@components/General/TWButtonGroup';
 import TooltipSelector, { TooltipKeys } from '@components/Tooltips/TooltipSelector';
 import Divider from '@components/General/Divider';
 import { poolMap } from '@libs/constants/poolLists';
-import {useWeb3, useWeb3Actions} from '@context/Web3Context/Web3Context';
+import { useWeb3, useWeb3Actions } from '@context/Web3Context/Web3Context';
 import { StaticPoolInfo } from '@libs/types/General';
 import { classNames } from '@libs/utils/functions';
 import { StyledTooltip } from '@components/Tooltips';

--- a/context/ThemeContext/index.tsx
+++ b/context/ThemeContext/index.tsx
@@ -1,6 +1,6 @@
 import { Children } from '@libs/types/General';
 import React, { useMemo, useEffect, useState } from 'react';
-import { Theme, themes } from './themes'
+import { Theme, themes } from './themes';
 
 interface ContextProps {
     isDark: boolean;
@@ -18,7 +18,7 @@ import { ThemeProvider } from 'styled-components';
  * Wrapper store for the FactoryContext.
  */
 export const ThemeStore: React.FC<Children> = ({ children }: Children) => {
-    const [theme, setTheme] = useState<Theme>('dark')
+    const [theme, setTheme] = useState<Theme>('dark');
     const isDark = useMemo(() => theme === 'dark', [theme]);
 
     const toggleTheme = () => {
@@ -27,18 +27,18 @@ export const ThemeStore: React.FC<Children> = ({ children }: Children) => {
             // is dark going to light
             localStorage.setItem('theme', 'light');
             head.classList.remove('theme-dark');
-            setTheme('light')
+            setTheme('light');
         } else {
             head.classList.add('theme-dark');
             localStorage.removeItem('theme');
-            setTheme('dark')
+            setTheme('dark');
         }
     };
 
     useEffect(() => {
         if (localStorage.getItem('theme') === 'light') {
-            setTheme('light')
-        } 
+            setTheme('light');
+        }
     }, []);
 
     return (
@@ -48,9 +48,7 @@ export const ThemeStore: React.FC<Children> = ({ children }: Children) => {
                 toggleTheme,
             }}
         >
-            <ThemeProvider theme={themes[theme]}>
-                {children}
-            </ThemeProvider>
+            <ThemeProvider theme={themes[theme]}>{children}</ThemeProvider>
         </ThemeContext.Provider>
     );
 };

--- a/context/ThemeContext/index.tsx
+++ b/context/ThemeContext/index.tsx
@@ -1,5 +1,6 @@
 import { Children } from '@libs/types/General';
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useEffect, useState } from 'react';
+import { Theme, themes } from './themes'
 
 interface ContextProps {
     isDark: boolean;
@@ -11,11 +12,14 @@ export const ThemeContext = React.createContext<ContextProps>({
     toggleTheme: () => undefined,
 });
 
+import { ThemeProvider } from 'styled-components';
+
 /**
  * Wrapper store for the FactoryContext.
  */
 export const ThemeStore: React.FC<Children> = ({ children }: Children) => {
-    const [isDark, setIsDark] = useState(true);
+    const [theme, setTheme] = useState<Theme>('dark')
+    const isDark = useMemo(() => theme === 'dark', [theme]);
 
     const toggleTheme = () => {
         const head = document.getElementsByTagName('html')[0];
@@ -23,18 +27,18 @@ export const ThemeStore: React.FC<Children> = ({ children }: Children) => {
             // is dark going to light
             localStorage.setItem('theme', 'light');
             head.classList.remove('theme-dark');
-            setIsDark(false);
+            setTheme('light')
         } else {
             head.classList.add('theme-dark');
             localStorage.removeItem('theme');
-            setIsDark(true);
+            setTheme('dark')
         }
     };
 
     useEffect(() => {
         if (localStorage.getItem('theme') === 'light') {
-            setIsDark(false);
-        }
+            setTheme('light')
+        } 
     }, []);
 
     return (
@@ -44,7 +48,9 @@ export const ThemeStore: React.FC<Children> = ({ children }: Children) => {
                 toggleTheme,
             }}
         >
-            {children}
+            <ThemeProvider theme={themes[theme]}>
+                {children}
+            </ThemeProvider>
         </ThemeContext.Provider>
     );
 };

--- a/context/ThemeContext/themes.ts
+++ b/context/ThemeContext/themes.ts
@@ -1,0 +1,83 @@
+export type Theme = 'dark' | 'light' | 'matrix'
+
+export const themes: Record< Theme, {
+    'background': string,
+    'background-secondary': string
+    'background-nav-secondary': string,
+    'text': string,
+    'text-secondary': string,
+    'border': string,
+    'primary': string,
+    'button-bg': string,
+    'button-bg-hover': string,
+}> = {
+    light: {
+        'background': '#fff',
+        /* gray-50 */
+        'background-secondary': '#f9fafb',
+        'background-nav-secondary': '#EEEEF6',
+
+        /* cool-gray-900 */
+        'text': '#111928',
+
+        /* cool-gray-700 */
+        'text-secondary': '#374151',
+
+        /* cool-gray-300*/
+        'border': '#D1D5DB',
+
+        /* tracer-800*/
+        'primary': '#0000B0',
+
+        /* cool-gray-50 */
+        'button-bg': '#F9FAFB',
+
+        /* cool-gray-100 */
+        'button-bg-hover': '#F3F4F6'
+    }, dark: {
+        /* cool-gray-900 */
+        'background': '#111928',
+
+        'background-secondary': '#1B2436',
+
+        /* cool-gray-900 */
+        'background-nav-secondary': '#111928',
+
+        /* gray-50 */
+        'text': '#FAFAFA',
+
+        /* cool-gray-200 */
+        'text-secondary': '#E5E7EB',
+
+        /* cool-gray-500*/
+        'border': '#6B7280',
+
+        /* tracer-100*/
+        'primary': '#DEDEFF',
+
+        /* cool-gray-800 */
+        'button-bg': '#1F2A37',
+
+        /* cool-gray-700 */
+        'button-bg-hover': '#374151'
+    }, matrix: {
+        /* cool-gray-900 */
+        'background': '#020204',
+
+        'background-secondary': '#003b00',
+
+        'background-nav-secondary': '#020204',
+
+        'text': '#22b455',
+
+        'text-secondary': '#80ce87',
+
+        'border': '#008f11',
+
+        'primary': '#00ff41',
+
+        'button-bg': '#003b00',
+
+        'button-bg-hover': '#020204'
+    }
+}

--- a/context/ThemeContext/themes.ts
+++ b/context/ThemeContext/themes.ts
@@ -1,42 +1,46 @@
-export type Theme = 'dark' | 'light' | 'matrix'
+export type Theme = 'dark' | 'light' | 'matrix';
 
-export const themes: Record< Theme, {
-    'background': string,
-    'background-secondary': string
-    'background-nav-secondary': string,
-    'text': string,
-    'text-secondary': string,
-    'border': string,
-    'primary': string,
-    'button-bg': string,
-    'button-bg-hover': string,
-}> = {
+export const themes: Record<
+    Theme,
+    {
+        background: string;
+        'background-secondary': string;
+        'background-nav-secondary': string;
+        text: string;
+        'text-secondary': string;
+        border: string;
+        primary: string;
+        'button-bg': string;
+        'button-bg-hover': string;
+    }
+> = {
     light: {
-        'background': '#fff',
+        background: '#fff',
         /* gray-50 */
         'background-secondary': '#f9fafb',
         'background-nav-secondary': '#EEEEF6',
 
         /* cool-gray-900 */
-        'text': '#111928',
+        text: '#111928',
 
         /* cool-gray-700 */
         'text-secondary': '#374151',
 
         /* cool-gray-300*/
-        'border': '#D1D5DB',
+        border: '#D1D5DB',
 
         /* tracer-800*/
-        'primary': '#0000B0',
+        primary: '#0000B0',
 
         /* cool-gray-50 */
         'button-bg': '#F9FAFB',
 
         /* cool-gray-100 */
-        'button-bg-hover': '#F3F4F6'
-    }, dark: {
+        'button-bg-hover': '#F3F4F6',
+    },
+    dark: {
         /* cool-gray-900 */
-        'background': '#111928',
+        background: '#111928',
 
         'background-secondary': '#1B2436',
 
@@ -44,40 +48,41 @@ export const themes: Record< Theme, {
         'background-nav-secondary': '#111928',
 
         /* gray-50 */
-        'text': '#FAFAFA',
+        text: '#FAFAFA',
 
         /* cool-gray-200 */
         'text-secondary': '#E5E7EB',
 
         /* cool-gray-500*/
-        'border': '#6B7280',
+        border: '#6B7280',
 
         /* tracer-100*/
-        'primary': '#DEDEFF',
+        primary: '#DEDEFF',
 
         /* cool-gray-800 */
         'button-bg': '#1F2A37',
 
         /* cool-gray-700 */
-        'button-bg-hover': '#374151'
-    }, matrix: {
+        'button-bg-hover': '#374151',
+    },
+    matrix: {
         /* cool-gray-900 */
-        'background': '#020204',
+        background: '#020204',
 
         'background-secondary': '#003b00',
 
         'background-nav-secondary': '#020204',
 
-        'text': '#22b455',
+        text: '#22b455',
 
         'text-secondary': '#80ce87',
 
-        'border': '#008f11',
+        border: '#008f11',
 
-        'primary': '#00ff41',
+        primary: '#00ff41',
 
         'button-bg': '#003b00',
 
-        'button-bg-hover': '#020204'
-    }
-}
+        'button-bg-hover': '#020204',
+    },
+};


### PR DESCRIPTION
Am proposing we slowly start using styled components. Every time I leave the code base and come back to tailwind after a while I just dislike it. We are using styled-components in pools-ui and its so much more usable imo. This shouldnt break any existing functionality, but will provide the theme contexts to create new components if you want to. Over time we can slowly start to convert old components, and they will also be slowly pushed into pools-ui component library as well.

Components are created and styled as 
```
const Wrap = styled.div`
  background-color: ${({ theme }) => theme.colors.background};
`;
```

This way we can go back to writing css. The main benefit I see of styled-components is 
- easier to follow designs. Tailwind allows you to have full custom css but it takes some setting up an when things change you have to change them.
- way easier to create re-usable components. Styled-components has a really nice API that allows you to create base components like the Wrap component above, and style it for specific use cases as you need. 
```
const StyledWrap = styled(Wrap)`
  background-color: ${({ theme }) => theme.colors['background-secondary']};
`;
```
its harder to do this in tailwind since all properties are !important. So it relies on variants. There is an argument here for forcing better code practices but its just annoying sometimes.

