### PR TITLE
Fix pending commits

### DIFF
--- a/archetypes/BalancerBuySell/index.tsx
+++ b/archetypes/BalancerBuySell/index.tsx
@@ -9,7 +9,7 @@ import TWButtonGroup from '@components/General/TWButtonGroup';
 import TooltipSelector, { TooltipKeys } from '@components/Tooltips/TooltipSelector';
 import Divider from '@components/General/Divider';
 import { poolMap } from '@libs/constants/poolLists';
-import {useWeb3, useWeb3Actions} from '@context/Web3Context/Web3Context';
+import { useWeb3, useWeb3Actions } from '@context/Web3Context/Web3Context';
 import { StaticPoolInfo } from '@libs/types/General';
 import { classNames } from '@libs/utils/functions';
 import { StyledTooltip } from '@components/Tooltips';

--- a/context/UsersCommitContext/commitDispatch.ts
+++ b/context/UsersCommitContext/commitDispatch.ts
@@ -25,7 +25,7 @@ export type CommitAction =
 export const reducer: (state: CommitsState, action: CommitAction) => CommitsState = (state, action) => {
     switch (action.type) {
         case 'addCommit':
-            const { id, pool } = action.commitInfo;
+            const { txnHash, pool } = action.commitInfo;
             const poolLower = pool.toLowerCase();
             console.debug('Adding commit', action.commitInfo);
             return {
@@ -34,7 +34,7 @@ export const reducer: (state: CommitsState, action: CommitAction) => CommitsStat
                     ...state.commits,
                     [`${poolLower}`]: {
                         ...state.commits[`${poolLower}`],
-                        [id]: action.commitInfo,
+                        [txnHash.toLowerCase()]: action.commitInfo,
                     },
                 },
             };

--- a/libs/utils/reputationAPI.ts
+++ b/libs/utils/reputationAPI.ts
@@ -62,7 +62,6 @@ export const fetchPoolCommits: (
                     pool: commit.pool_address,
                 });
             });
-            console.info('Parsed commits', parsedCommits);
             return parsedCommits;
         })
         .catch((err) => {

--- a/libs/utils/reputationAPI.ts
+++ b/libs/utils/reputationAPI.ts
@@ -45,7 +45,7 @@ export const fetchPoolCommits: (
 ) => Promise<APICommitReturn[]> = async (network, { pool, from, to, account }) => {
     const route = `${BASE_REPUTATION_API}/commits?source=${SourceMap[network]}&from=${from ?? 0}&to=${
         to ?? Math.round(Date.now() / 1000)
-    }${!!pool ? `&pool_address=${pool?.toLowerCase()}}` : ''}${!!account ? `&committer_address=${account}` : ''}`;
+    }${!!pool ? `&pool_address=${pool?.toLowerCase()}` : ''}${!!account ? `&committer_address=${account}` : ''}`;
     const commits: APICommitReturn[] = await fetch(route)
         .then((res) => res.json())
         .then((commits) => {
@@ -62,6 +62,7 @@ export const fetchPoolCommits: (
                     pool: commit.pool_address,
                 });
             });
+            console.log('Parsed commits', parsedCommits);
             return parsedCommits;
         })
         .catch((err) => {

--- a/libs/utils/reputationAPI.ts
+++ b/libs/utils/reputationAPI.ts
@@ -62,7 +62,7 @@ export const fetchPoolCommits: (
                     pool: commit.pool_address,
                 });
             });
-            console.log('Parsed commits', parsedCommits);
+            console.info('Parsed commits', parsedCommits);
             return parsedCommits;
         })
         .catch((err) => {


### PR DESCRIPTION
Ticket for #437 
Pending commits were not showing after after toaster minimised. This is because the API request had a slight error in it.

## Changes
- use txn hash to identify commits instead of ID. Reputation does not return the commit ID
- fix request route