### PR TITLE
generalise staking reward asset pricing to prep for FXS staking rewards

### DIFF
--- a/archetypes/Stake/FarmsTable/index.tsx
+++ b/archetypes/Stake/FarmsTable/index.tsx
@@ -13,7 +13,7 @@ import { calcAPY, calcBptTokenPrice } from '@tracer-protocol/tracer-pools-utils'
 import { APYTip, RewardsEndedTip } from '@components/Tooltips';
 import { TokenToFarmAddressMap } from '@libs/constants';
 
-export default (({ rows, onClickStake, onClickUnstake, onClickClaim, fetchingFarms, tcrUSDCPrice }) => {
+export default (({ rows, onClickStake, onClickUnstake, onClickClaim, fetchingFarms, rewardsTokenUSDPrices }) => {
     const [showModal, setShowModal] = useState(false);
 
     return (
@@ -36,7 +36,7 @@ export default (({ rows, onClickStake, onClickUnstake, onClickClaim, fetchingFar
                             key={`${farm}-${index}`}
                             farm={farm}
                             index={index}
-                            tcrUSDCPrice={tcrUSDCPrice}
+                            rewardsTokenUSDPrices={rewardsTokenUSDPrices}
                             onClickClaim={onClickClaim}
                             onClickStake={onClickStake}
                             onClickUnstake={onClickUnstake}
@@ -84,17 +84,17 @@ export default (({ rows, onClickStake, onClickUnstake, onClickClaim, fetchingFar
     onClickUnstake: (farmAddress: string) => void;
     onClickClaim: (farmAddress: string) => void;
     fetchingFarms: boolean;
-    tcrUSDCPrice: BigNumber;
+    rewardsTokenUSDPrices: Record<string, BigNumber>;
 }>;
 
 const PoolRow: React.FC<{
     farm: FarmTableRowData;
     index: number;
-    tcrUSDCPrice: BigNumber;
+    rewardsTokenUSDPrices: Record<string, BigNumber>;
     onClickStake: (farmAddress: string) => void;
     onClickUnstake: (farmAddress: string) => void;
     onClickClaim: (farmAddress: string) => void;
-}> = ({ farm, onClickStake, onClickUnstake, onClickClaim, index, tcrUSDCPrice }) => {
+}> = ({ farm, onClickStake, onClickUnstake, onClickClaim, index, rewardsTokenUSDPrices }) => {
     const tokenPrice = useMemo(
         () =>
             farm?.poolDetails
@@ -103,11 +103,13 @@ const PoolRow: React.FC<{
         [farm],
     );
 
+    const rewardsTokenPrice = rewardsTokenUSDPrices[farm.rewardsTokenAddress] || new BigNumber(0);
+
     const apr = useMemo(() => {
-        const aprNumerator = farm.rewardsPerYear.times(tcrUSDCPrice);
+        const aprNumerator = farm.rewardsPerYear.times(rewardsTokenPrice);
         const aprDenominator = tokenPrice.times(farm.totalStaked);
         return aprDenominator.gt(0) ? aprNumerator.div(aprDenominator) : new BigNumber(0);
-    }, [tokenPrice, farm.totalStaked, farm.rewardsPerYear, tcrUSDCPrice]);
+    }, [tokenPrice, farm.totalStaked, farm.rewardsPerYear, rewardsTokenPrice]);
 
     const apy = useMemo(() => calcAPY(apr), [apr]);
 

--- a/archetypes/Stake/StakeBPT/index.tsx
+++ b/archetypes/Stake/StakeBPT/index.tsx
@@ -4,7 +4,7 @@ import StakeGeneric from '../StakeGeneric';
 import { useFarms } from '@context/FarmContext';
 
 export default (() => {
-    const { farms, refreshFarm, fetchingFarms, tcrUSDCPrice } = useFarms();
+    const { farms, refreshFarm, fetchingFarms, rewardsTokenUSDPrices } = useFarms();
     return (
         <StakeGeneric
             logo="BALANCER"
@@ -14,7 +14,7 @@ export default (() => {
             refreshFarm={refreshFarm}
             fetchingFarms={fetchingFarms}
             farms={farms}
-            tcrUSDCPrice={tcrUSDCPrice}
+            rewardsTokenUSDPrices={rewardsTokenUSDPrices}
             hideSideFilter
         />
     );

--- a/archetypes/Stake/StakeGeneric/index.tsx
+++ b/archetypes/Stake/StakeGeneric/index.tsx
@@ -60,7 +60,7 @@ export default (({
     hideLeverageFilter,
     hideSideFilter,
     fetchingFarms,
-    tcrUSDCPrice,
+    rewardsTokenUSDPrices,
 }) => {
     const { account } = useWeb3();
     const { handleTransaction } = useTransactionContext();
@@ -88,6 +88,7 @@ export default (({
             link: farm.link,
             linkText: farm.linkText,
             rewardsEnded: farm.rewardsEnded,
+            rewardsTokenAddress: farm.rewardsTokenAddress,
         };
     });
 
@@ -369,7 +370,7 @@ export default (({
                     <FarmsTable
                         rows={sortedFilteredFarms}
                         fetchingFarms={fetchingFarms}
-                        tcrUSDCPrice={tcrUSDCPrice}
+                        rewardsTokenUSDPrices={rewardsTokenUSDPrices}
                         onClickClaim={handleClaim}
                         onClickUnstake={handleUnstake}
                         onClickStake={handleStake}
@@ -398,7 +399,7 @@ export default (({
     hideLeverageFilter?: boolean;
     hideSideFilter?: boolean;
     fetchingFarms: boolean;
-    tcrUSDCPrice: BigNumber;
+    rewardsTokenUSDPrices: Record<string, BigNumber>;
 }>;
 
 const StakeModalWithState: React.FC<{

--- a/archetypes/Stake/StakePool/index.tsx
+++ b/archetypes/Stake/StakePool/index.tsx
@@ -4,7 +4,7 @@ import StakeGeneric from '../StakeGeneric';
 import { useFarms } from '@context/FarmContext';
 
 export default (() => {
-    const { farms, refreshFarm, fetchingFarms, tcrUSDCPrice } = useFarms();
+    const { farms, refreshFarm, fetchingFarms, rewardsTokenUSDPrices } = useFarms();
 
     return (
         <>
@@ -15,7 +15,7 @@ export default (() => {
                 refreshFarm={refreshFarm}
                 farms={farms}
                 fetchingFarms={fetchingFarms}
-                tcrUSDCPrice={tcrUSDCPrice}
+                rewardsTokenUSDPrices={rewardsTokenUSDPrices}
             />
         </>
     );

--- a/libs/types/Staking.ts
+++ b/libs/types/Staking.ts
@@ -20,6 +20,7 @@ export type FarmTableDetails = {
     stakingTokenSupply: BigNumber;
     rewardsPerYear: BigNumber;
     rewardsEnded: boolean;
+    rewardsTokenAddress: string;
     link?: string;
     linkText?: string;
     bptDetails?: {


### PR DESCRIPTION
# Motivation
We plan on launching a staking farm where rewards are paid in FXS. Currently, the UI only supports LM rewards paid in TCR. 

# Changes
Generalize the storage of reward token pricing so we can add additional reward token prices for use in APY/APR calculations