### PR TITLE
add FXS USD pricing for use in LM reward calcs

### DIFF
--- a/archetypes/Stake/StakeBPT/index.tsx
+++ b/archetypes/Stake/StakeBPT/index.tsx
@@ -9,7 +9,7 @@ export default (() => {
         <StakeGeneric
             logo="BALANCER"
             title="Balancer Pool Token Strategies"
-            subTitle="Stake Balancer Pool Tokens and earn TCR."
+            subTitle="Stake Balancer Pool Tokens to earn rewards."
             tokenType="Balancer Pool"
             refreshFarm={refreshFarm}
             fetchingFarms={fetchingFarms}

--- a/archetypes/Stake/StakeBPT/index.tsx
+++ b/archetypes/Stake/StakeBPT/index.tsx
@@ -9,7 +9,7 @@ export default (() => {
         <StakeGeneric
             logo="BALANCER"
             title="Balancer Pool Token Strategies"
-            subTitle="Stake Balancer Pool Tokens to earn rewards."
+            subTitle="Stake Balancer Pool Tokens and earn rewards."
             tokenType="Balancer Pool"
             refreshFarm={refreshFarm}
             fetchingFarms={fetchingFarms}

--- a/archetypes/Stake/StakePool/index.tsx
+++ b/archetypes/Stake/StakePool/index.tsx
@@ -10,7 +10,7 @@ export default (() => {
         <>
             <StakeGeneric
                 title="Stake Tracer Pool Tokens"
-                subTitle="Stake Tracer Pool Tokens and earn TCR."
+                subTitle="Stake Tracer Pool Tokens and earn rewards."
                 tokenType="Tracer Pool"
                 refreshFarm={refreshFarm}
                 farms={farms}

--- a/context/Web3Context/Web3Context.Config.ts
+++ b/context/Web3Context/Web3Context.Config.ts
@@ -51,6 +51,12 @@ export type Network = {
     };
     tcrAddress: string;
     sushiRouterAddress: string;
+    stakingRewardTokens?: {
+        [key: string]: {
+            address: string;
+            decimals: number;
+        };
+    };
     balancerInfo?: {
         graphUri: string;
         baseUri: string; // base link to balancer trading page
@@ -264,6 +270,12 @@ export const networkConfig: Record<AvailableNetwork, Network> = {
         },
         sushiRouterAddress: '0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506',
         tcrAddress: '0xA72159FC390f0E3C6D415e658264c7c4051E9b87',
+        stakingRewardTokens: {
+            fxs: {
+                address: '0x9d2f299715d94d8a7e6f5eaa8e654e8c74a988a7',
+                decimals: 18,
+            },
+        },
         balancerInfo: {
             graphUri: 'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2',
             baseUri: 'https://arbitrum.balancer.fi/#/trade',


### PR DESCRIPTION
# Motivation
When we release staking farms paid in FXS, we need the USD price of FXS to calculate reward rates

# Changes
- Refactor fetching of reward token pricing to support arbitrary tokens
- Add FXS as a known staking reward token, this causes the farm context to fetch its USDC price during initialization