### PR TITLE
Invalid amount summary state display

### DIFF
--- a/archetypes/Exchange/Summary/MintSummary.tsx
+++ b/archetypes/Exchange/Summary/MintSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Section } from '@components/General';
 import { toApproxCurrency } from '@libs/utils/converters';
 import * as Styles from './styles';
@@ -6,8 +6,9 @@ import ApproxCommitGasFee from './ApproxCommitGasFee';
 import { ExpectedTokenPrice } from './Sections';
 import { MintSummaryProps } from './types';
 import ArrowDown from '@public/img/general/caret-down-white.svg';
+import { Skeleton } from 'antd';
 
-const MintSummary: React.FC<MintSummaryProps> = ({ amount, tokenPrice, token, pool, gasFee }) => {
+const MintSummary: React.FC<MintSummaryProps> = ({ amount, tokenPrice, token, pool, gasFee, showBreakdown }) => {
     const [showTransactionDetails, setShowTransactionDetails] = useState(false);
 
     const expectedAmount = amount.div(tokenPrice ?? 1).toFixed(0);
@@ -18,13 +19,24 @@ const MintSummary: React.FC<MintSummaryProps> = ({ amount, tokenPrice, token, po
     const expectedTokensMinted = `${Number(expectedAmount) > 0 ? expectedAmount : ''} ${token.symbol}`;
     const selectedToken = pool.name?.split('-')[1]?.split('/')[0];
     const selectedTokenOraclePrice = toApproxCurrency(pool.oraclePrice);
-    const equivalentExposure = (amount.div(pool.oraclePrice.toNumber()).times(poolPowerLeverage)).toNumber();
+    const equivalentExposure = amount.div(pool.oraclePrice.toNumber()).times(poolPowerLeverage).toNumber();
 
-    const commitAmount = amount.div(pool.oraclePrice).toNumber()
+    const commitAmount = amount.div(pool.oraclePrice).toNumber();
+
+    useEffect(() => {
+        if (!showBreakdown) {
+            setShowTransactionDetails(false);
+        }
+    }, [showBreakdown]);
+
     return (
         <>
             <Section label="Total Costs" className="header">
-                <Styles.SumText>{totalCost}</Styles.SumText>
+                {showBreakdown ? (
+                    <Styles.SumText>{totalCost}</Styles.SumText>
+                ) : (
+                    <Skeleton active paragraph={{ rows: 1, width: '100%' }} title={false} />
+                )}
             </Section>
             {showTransactionDetails && (
                 <Styles.SectionDetails>
@@ -39,7 +51,11 @@ const MintSummary: React.FC<MintSummaryProps> = ({ amount, tokenPrice, token, po
                 </Styles.SectionDetails>
             )}
             <Section label="Expected Tokens Minted" className="header">
-                <Styles.SumText>{expectedTokensMinted}</Styles.SumText>
+                {showBreakdown ? (
+                    <Styles.SumText>{expectedTokensMinted}</Styles.SumText>
+                ) : (
+                    <Skeleton active paragraph={{ rows: 1, width: '100%' }} title={false} />
+                )}
             </Section>
             {showTransactionDetails && (
                 <Styles.SectionDetails>
@@ -54,9 +70,13 @@ const MintSummary: React.FC<MintSummaryProps> = ({ amount, tokenPrice, token, po
                 </Styles.SectionDetails>
             )}
             <Section label="Expected Equivalent Exposure" className="header">
-                <Styles.SumText setColor="green">
-                    {equivalentExposure.toFixed(3)} {selectedToken}
-                </Styles.SumText>
+                {showBreakdown ? (
+                    <Styles.SumText setColor="green">
+                        {equivalentExposure.toFixed(3)} {selectedToken}
+                    </Styles.SumText>
+                ) : (
+                    <Skeleton active paragraph={{ rows: 1, width: '100%' }} title={false} />
+                )}
             </Section>
             {showTransactionDetails && (
                 <Styles.SectionDetails>
@@ -73,9 +93,11 @@ const MintSummary: React.FC<MintSummaryProps> = ({ amount, tokenPrice, token, po
                     </Section>
                 </Styles.SectionDetails>
             )}
-            <Styles.ShowDetailsButton onClick={() => setShowTransactionDetails(!showTransactionDetails)}>
-                <ArrowDown className={`${showTransactionDetails ? 'open' : ''}`} />
-            </Styles.ShowDetailsButton>
+            {showBreakdown && (
+                <Styles.ShowDetailsButton onClick={() => setShowTransactionDetails(!showTransactionDetails)}>
+                    <ArrowDown className={`${showTransactionDetails ? 'open' : ''}`} />
+                </Styles.ShowDetailsButton>
+            )}
         </>
     );
 };

--- a/archetypes/Exchange/Summary/index.tsx
+++ b/archetypes/Exchange/Summary/index.tsx
@@ -13,9 +13,9 @@ export default (({ pool, showBreakdown, amount, isLong, receiveIn, commitAction,
     const tokenPrice = useMemo(() => (isLong ? pool.getNextLongTokenPrice() : pool.getNextShortTokenPrice()), [isLong]);
     return (
         <Styles.HiddenExpand defaultHeight={0} open={!!pool.name} showBorder={!!pool.name}>
-            <Styles.Wrapper>
+            <Styles.Wrapper isSummaryAvailable={showBreakdown}>
                 <Transition
-                    show={showBreakdown}
+                    show
                     enter="transition-opacity duration-50 delay-100"
                     enterFrom="opacity-0"
                     enterTo="opacity-100"
@@ -34,6 +34,7 @@ export default (({ pool, showBreakdown, amount, isLong, receiveIn, commitAction,
                                 leverage: pool.leverage,
                             }}
                             gasFee={gasFee}
+                            showBreakdown={showBreakdown}
                         />
                     )}
 

--- a/archetypes/Exchange/Summary/styles.tsx
+++ b/archetypes/Exchange/Summary/styles.tsx
@@ -13,8 +13,8 @@ export const HiddenExpand = styled(UnstyledHiddenExpand)<{ showBorder: boolean }
     border-color: ${({ showBorder, theme }) => (showBorder ? theme['border-secondary'] : 'transparent')};
 `;
 
-export const Wrapper = styled.div`
-    padding: 1.5rem 1rem 0;
+export const Wrapper = styled.div<{ isSummaryAvailable?: boolean }>`
+    padding: ${({ isSummaryAvailable }) => `1.5rem 1rem ${isSummaryAvailable ? '0' : '1'}rem`};
     position: relative;
 `;
 

--- a/archetypes/Exchange/Summary/types.ts
+++ b/archetypes/Exchange/Summary/types.ts
@@ -19,6 +19,7 @@ type SharedProps = {
 
     tokenPrice: BigNumber;
     token: PoolToken;
+    showBreakdown?: boolean;
 };
 
 export type FlipSummaryProps = {


### PR DESCRIPTION
Problem: Collapsing summary when an invalid amount is selected
<img src="https://user-images.githubusercontent.com/97488700/158468999-b1a385a8-2164-4900-b1af-9475c951fa7c.png" width="400" />
 
Solution: Work in progress, PR is using skeleton from antd but I'm adding images of other options. Still need to implement burn and flip if the team agrees to move forward.
<img src="https://user-images.githubusercontent.com/97488700/158469337-6b559106-3b7e-4cb8-b091-7a0ce6ca9956.png" width="400"/>
<img src="https://user-images.githubusercontent.com/97488700/158469343-29a6be3a-cef9-456e-9dfe-4dd775d854ee.png" width="400"/>
<img src="https://user-images.githubusercontent.com/97488700/158469344-600e43cb-0f8a-470f-b91a-49a8c7f04aed.png" width="400"/>