### PR TITLE
Properly handle selection of poolLists

### DIFF
--- a/hooks/useAllPoolLists/index.ts
+++ b/hooks/useAllPoolLists/index.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { StaticPoolInfo } from '@tracer-protocol/pools-js';
+import { useStore } from '~/store/main';
+import { StoreState } from '~/store/types';
+import { selectNetwork } from '~/store/Web3Slice';
+import { flattenAllPoolLists } from '~/utils/poolLists';
+
+// wrapper hook to memoize fetching of poolLists
+export const useAllPoolLists = (): StaticPoolInfo[] => {
+    const ref = useRef<StaticPoolInfo[]>([]);
+    const network = useStore(selectNetwork);
+    const poolLists = useStore(
+        useCallback((state: StoreState) => network && state.poolsSlice.poolLists[network], [network]),
+    );
+
+    useEffect(() => {
+        if (!!poolLists) {
+            console.count('Flattening pools list');
+            ref.current = flattenAllPoolLists(poolLists);
+        }
+    }, [poolLists]);
+
+    return ref.current;
+};

--- a/hooks/usePoolWatcher/index.tsx
+++ b/hooks/usePoolWatcher/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { ethers } from 'ethers';
 import BigNumber from 'bignumber.js';
 import shallow from 'zustand/shallow';
@@ -8,21 +8,20 @@ import { networkConfig } from '~/constants/networks';
 import { useStore } from '~/store/main';
 import { selectUserCommitActions } from '~/store/PendingCommitSlice';
 import { selectPoolInstanceActions, selectPoolInstanceUpdateActions } from '~/store/PoolInstancesSlice';
-import { selectAllPoolLists } from '~/store/PoolsSlice';
 import { selectWeb3Info } from '~/store/Web3Slice';
+import { useAllPoolLists } from '../useAllPoolLists';
 
 export const usePoolWatcher = (): void => {
     const currentSubscribed = useRef<string | undefined>();
-    const pools = useStore(selectAllPoolLists, (oldState, newState) => oldState.length === newState.length);
-    const poolAddresses = useMemo(() => pools.map((pool) => pool.address), [pools.length]);
     const { network, account } = useStore(selectWeb3Info, shallow);
     const { addCommit, removeCommits } = useStore(selectUserCommitActions, shallow);
     const { setPoolIsWaiting, setPoolExpectedExecution } = useStore(selectPoolInstanceActions, shallow);
     const { handlePoolUpkeep } = useStore(selectPoolInstanceUpdateActions, shallow);
+    const poolLists = useAllPoolLists();
 
-    useMemo(() => {
+    useEffect(() => {
         const wssProvider = networkConfig[network as KnownNetwork]?.publicWebsocketRPC;
-        if (!!poolAddresses?.length && !!wssProvider && !!network) {
+        if (!!poolLists?.length && !!wssProvider && !!network) {
             if (!currentSubscribed.current || currentSubscribed.current !== network) {
                 currentSubscribed.current = network;
                 console.count(`Setting pool watcher: ${network}`);
@@ -31,7 +30,7 @@ export const usePoolWatcher = (): void => {
                     nodeUrl: wssProvider,
                     commitmentWindowBuffer: 20, // calculate and emit expected state 20 seconds before expected end of commitment window
                     chainId: network,
-                    poolAddresses: poolAddresses,
+                    poolAddresses: poolLists.map((pool) => pool.address),
                 });
 
                 watcher.initializePoolWatchers().then(() => {
@@ -76,7 +75,7 @@ export const usePoolWatcher = (): void => {
                 });
             }
         }
-    }, [poolAddresses, network]);
+    }, [poolLists, network]);
 };
 
 export default usePoolWatcher;

--- a/hooks/useUpdatePoolInstances/index.ts
+++ b/hooks/useUpdatePoolInstances/index.ts
@@ -85,7 +85,7 @@ export const useUpdatePoolInstances = (): void => {
         return () => {
             mounted = false;
         };
-    }, [poolLists]);
+    }, [provider, poolLists]);
 
     // fetch all pending commits
     useEffect(() => {

--- a/hooks/useUpdatePoolInstances/index.ts
+++ b/hooks/useUpdatePoolInstances/index.ts
@@ -11,11 +11,11 @@ import {
     selectPoolInstanceUpdateActions,
     selectPoolsInitialized,
 } from '~/store/PoolInstancesSlice';
-import { selectAllPoolLists } from '~/store/PoolsSlice';
 import { selectWeb3Info } from '~/store/Web3Slice';
 
 import { isSupportedNetwork } from '~/utils/supportedNetworks';
 import { fetchPendingCommits, V2_SUPPORTED_NETWORKS } from '~/utils/tracerAPI';
+import { useAllPoolLists } from '../useAllPoolLists';
 
 /**
  * Wrapper to update all pools information
@@ -28,7 +28,7 @@ export const useUpdatePoolInstances = (): void => {
     const { updateTokenApprovals, updateTokenBalances } = useStore(selectPoolInstanceUpdateActions, shallow);
     const { addCommit } = useStore(selectUserCommitActions, shallow);
     const { provider, account } = useStore(selectWeb3Info, shallow);
-    const poolAddresses = useStore(selectAllPoolLists, (oldState, newState) => oldState.length === newState.length);
+    const poolLists = useAllPoolLists();
     const pools = useStore(selectPoolInstances);
     const poolsInitialized = useStore(selectPoolsInitialized);
 
@@ -40,7 +40,7 @@ export const useUpdatePoolInstances = (): void => {
         let mounted = true;
         console.debug('Attempting to initialise pools');
         // this is not the greatest for the time being
-        if (!!poolAddresses.length && provider?.network?.chainId) {
+        if (!!poolLists.length && provider?.network?.chainId) {
             const network = provider.network?.chainId?.toString();
             if (isSupportedNetwork(network)) {
                 const fetchAndSetPools = async () => {
@@ -49,7 +49,7 @@ export const useUpdatePoolInstances = (): void => {
                     hasSetPools.current = false;
                     setPoolsInitialized(false);
                     Promise.all(
-                        poolAddresses.map((pool) =>
+                        poolLists.map((pool) =>
                             Pool.Create({
                                 ...pool,
                                 address: pool.address,
@@ -85,7 +85,7 @@ export const useUpdatePoolInstances = (): void => {
         return () => {
             mounted = false;
         };
-    }, [poolAddresses.length]);
+    }, [poolLists]);
 
     // fetch all pending commits
     useEffect(() => {

--- a/hooks/useUpkeeps/index.tsx
+++ b/hooks/useUpkeeps/index.tsx
@@ -70,7 +70,7 @@ export const useUpkeeps: (network: KnownNetwork | undefined) => Record<string, U
                         }
                     }
                 } catch (error: any) {
-                    console.error(`Error getting last 2 upkeeps for pool ${pool}: ${error.message}`);
+                    console.error(`Error getting last 2 upkeeps for pool ${pool.address}: ${error.message}`);
                 }
             });
 

--- a/hooks/useUpkeeps/index.tsx
+++ b/hooks/useUpkeeps/index.tsx
@@ -2,10 +2,9 @@ import { useEffect, useState } from 'react';
 import { ethers } from 'ethers';
 import BigNumber from 'bignumber.js';
 import { KnownNetwork, calcSkew, calcTokenPrice } from '@tracer-protocol/pools-js';
-import { useStore } from '~/store/main';
-import { selectAllPoolLists } from '~/store/PoolsSlice';
 import { V2_SUPPORTED_NETWORKS } from '~/utils/tracerAPI';
 import { last2UpkeepsQuery, subgraphUrlByNetwork } from '~/utils/tracerAPI/subgraph';
+import { useAllPoolLists } from '../useAllPoolLists';
 
 export type Upkeep = {
     pool: string;
@@ -40,11 +39,10 @@ type RawUpkeep = {
 // const useUpkeeps
 export const useUpkeeps: (network: KnownNetwork | undefined) => Record<string, Upkeep[]> = (network) => {
     const [upkeeps, setUpkeeps] = useState<Record<string, Upkeep[]>>({});
-    const poolList = useStore(selectAllPoolLists, (oldState, newState) => oldState.length === newState.length);
+    const poolLists = useAllPoolLists();
 
     useEffect(() => {
         let mounted = true;
-
         const fetchUpkeeps = async () => {
             const graphUrl = subgraphUrlByNetwork[network as V2_SUPPORTED_NETWORKS];
 
@@ -54,7 +52,7 @@ export const useUpkeeps: (network: KnownNetwork | undefined) => Record<string, U
 
             const upkeepMapping: Record<string, Upkeep[]> = {};
 
-            const promises = poolList.map(async (pool) => {
+            const promises = poolLists.map(async (pool) => {
                 try {
                     const last2Upkeeps = await fetch(graphUrl, {
                         method: 'POST',
@@ -72,7 +70,7 @@ export const useUpkeeps: (network: KnownNetwork | undefined) => Record<string, U
                         }
                     }
                 } catch (error: any) {
-                    console.error(`Error getting last 2 upkeeps for pool ${pool.address}: ${error.message}`);
+                    console.error(`Error getting last 2 upkeeps for pool ${pool}: ${error.message}`);
                 }
             });
 
@@ -90,7 +88,7 @@ export const useUpkeeps: (network: KnownNetwork | undefined) => Record<string, U
         return () => {
             mounted = false;
         };
-    }, [network, poolList.length]);
+    }, [network, poolLists]);
 
     return upkeeps;
 };

--- a/store/PoolsSlice/index.tsx
+++ b/store/PoolsSlice/index.tsx
@@ -1,6 +1,6 @@
 import { StaticPoolInfo } from '@tracer-protocol/pools-js';
 import { StateSlice } from '~/store/types';
-import { getAllPoolLists, flattenAllPoolLists } from '~/utils/poolLists';
+import { getAllPoolLists } from '~/utils/poolLists';
 import { IPoolsSlice } from './types';
 import { StoreState } from '..';
 
@@ -12,7 +12,6 @@ export const createPoolsSlice: StateSlice<IPoolsSlice> = (set, get) => ({
     importPool: (network, pool) => {
         if (get().poolLists[network]) {
             set((state) => void state.poolLists[network]?.Imported.pools.push({ address: pool }));
-            // set(state => void (state.poolLists[network]?.All.push({ address: pool })))
         }
     },
     fetchPoolLists: async (network) => {
@@ -27,9 +26,6 @@ export const createPoolsSlice: StateSlice<IPoolsSlice> = (set, get) => ({
         }
     },
 });
-
-export const selectAllPoolLists: (state: StoreState) => StaticPoolInfo[] = (state) =>
-    state.web3Slice.network ? flattenAllPoolLists(state.poolsSlice.poolLists[state.web3Slice.network]) : [];
 
 export const selectImportedPools: (state: StoreState) => StaticPoolInfo[] = (state) =>
     state.web3Slice.network ? state.poolsSlice.poolLists[state.web3Slice.network]?.Imported?.pools ?? [] : [];

--- a/store/Web3Slice/index.ts
+++ b/store/Web3Slice/index.ts
@@ -100,7 +100,8 @@ export const createWeb3Slice: StateSlice<IWeb3Slice> = (set, get) => ({
 export const selectWeb3Slice: (state: StoreState) => IWeb3Slice = (state) => state.web3Slice;
 export const selectProvider: (state: StoreState) => IWeb3Slice['provider'] = (state) =>
     state.web3Slice.provider ?? state.web3Slice.defaultProvider;
-export const selectNetwork: (state: StoreState) => IWeb3Slice['network'] = (state) => state.web3Slice.network;
+export const selectNetwork: (state: StoreState) => IWeb3Slice['network'] = (state) =>
+    state.web3Slice.network ?? DEFAULT_NETWORK;
 export const selectAccount: (state: StoreState) => IWeb3Slice['account'] = (state) => state.web3Slice.account;
 export const selectHandleConnect: (state: StoreState) => IWeb3Slice['handleConnect'] = (state) =>
     state.web3Slice.handleConnect;


### PR DESCRIPTION
Handle proper selection of poolLsits. This fixes the bug of pools not reloading when network changes
- create usePoolLists hook which fetches the pools list based on the network, uses a memoized selector to avoid multiple selections
- only update ref when poolsList changes