### PR TITLE
Add commit straight after txn

### DIFF
--- a/components/TokenActions/index.tsx
+++ b/components/TokenActions/index.tsx
@@ -1,13 +1,12 @@
 import React, { useState } from 'react';
 import { ethers } from 'ethers';
 import { MoreOutlined, PlusOutlined } from '@ant-design/icons';
+import { Popover } from 'react-tiny-popover';
 import { KnownNetwork, NETWORKS } from '@tracer-protocol/pools-js';
 import { Logo, LogoTicker } from '~/components/General';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
 import { openBlockExplorer } from '~/utils/blockExplorers';
 import { watchAsset } from '~/utils/rpcMethods';
-
-import { Popover } from 'react-tiny-popover';
 
 export default (({ provider, token, arbiscanTarget, otherActions }) => {
     const [isOpen, setIsOpen] = useState<boolean>(false);

--- a/hooks/usePoolInstanceActions/index.ts
+++ b/hooks/usePoolInstanceActions/index.ts
@@ -10,6 +10,7 @@ import {
 } from '@tracer-protocol/pools-js';
 import { CommitToQueryFocusMap } from '~/constants/index';
 import { useStore } from '~/store/main';
+import { selectAddCommit } from '~/store/PendingCommitSlice';
 import {
     selectPoolInstanceActions,
     selectPoolInstances,
@@ -18,6 +19,7 @@ import {
 import { selectHandleTransaction } from '~/store/TransactionSlice';
 import { TransactionType } from '~/store/TransactionSlice/types';
 import { selectWeb3Info } from '~/store/Web3Slice';
+import { fromAggregateBalances } from '~/utils/pools';
 
 type Options = {
     onSuccess?: (...args: any) => any;
@@ -40,11 +42,13 @@ interface PoolInstanceActions {
         amount: BigNumber,
     ) => Promise<BigNumber>;
 }
-import { fromAggregateBalances } from '~/utils/pools';
+
+const committerInterface = new ethers.utils.Interface(PoolCommitter__factory.abi);
 
 export const usePoolInstanceActions = (): PoolInstanceActions => {
     const { setTokenApproved } = useStore(selectPoolInstanceActions, shallow);
     const { updateTokenBalances } = useStore(selectPoolInstanceUpdateActions, shallow);
+    const addCommit = useStore(selectAddCommit);
     const handleTransaction = useStore(selectHandleTransaction);
     const { provider, account, signer } = useStore(selectWeb3Info, shallow);
     const pools = useStore(selectPoolInstances);
@@ -187,11 +191,34 @@ export const usePoolInstanceActions = (): PoolInstanceActions => {
                     expectedExecution: expectedExecution,
                 },
                 callBacks: {
-                    onSuccess: (receipt) => {
+                    onSuccess: async (receipt) => {
                         console.debug('Successfully submitted commit txn: ', receipt);
                         // get and set token balances
                         updateTokenBalances(pool, provider, account);
                         options?.onSuccess ? options.onSuccess(receipt) : null;
+                        // @ts-ignore receipt type is a bitch
+                        const txnHash = (receipt as any)?.transactionHash ?? '';
+                        const parsedLogs = (receipt as any)?.logs?.map((log: any) => {
+                            try {
+                                return committerInterface.parseLog(log);
+                            } catch (_err) {
+                                return undefined;
+                            }
+                        });
+                        const createdCommit = parsedLogs?.find((log: any) => log?.name === 'CreateCommit');
+                        if (!!createdCommit) {
+                            const commitInfo = createdCommit.args;
+                            addCommit({
+                                pool: pool.slice(),
+                                txnHash: txnHash as string,
+                                id: txnHash,
+                                type: commitType,
+                                amount: new BigNumber(ethers.utils.formatUnits(commitInfo.amount)),
+                                from: commitInfo.user,
+                                created: Math.floor(Date.now() / 1000),
+                                appropriateIntervalId: commitInfo.appropriateUpdateIntervalId.toNumber(),
+                            });
+                        }
                     },
                 },
             });

--- a/hooks/usePoolInstanceActions/index.ts
+++ b/hooks/usePoolInstanceActions/index.ts
@@ -191,7 +191,7 @@ export const usePoolInstanceActions = (): PoolInstanceActions => {
                     expectedExecution: expectedExecution,
                 },
                 callBacks: {
-                    onSuccess: async (receipt) => {
+                    onSuccess: (receipt) => {
                         console.debug('Successfully submitted commit txn: ', receipt);
                         // get and set token balances
                         updateTokenBalances(pool, provider, account);

--- a/hooks/usePoolWatcher/index.tsx
+++ b/hooks/usePoolWatcher/index.tsx
@@ -36,6 +36,7 @@ export const usePoolWatcher = (): void => {
                     watcher.on(EVENT_NAMES.COMMIT, (commitInfo) => {
                         console.debug('Received commit', commitInfo);
                         if (commitInfo.user.toLowerCase() === account?.toLowerCase()) {
+                            console.log('Adding event commit');
                             addCommit({
                                 pool: commitInfo.poolAddress,
                                 id: commitInfo.txHash,

--- a/store/PendingCommitSlice/index.tsx
+++ b/store/PendingCommitSlice/index.tsx
@@ -38,6 +38,8 @@ export const createPendingCommitSlice: StateSlice<IPendingCommitSlice> = (set) =
 export const selectCommits: (state: StoreState) => IPendingCommitSlice['commits'] = (state) =>
     state.pendingCommitSlice.commits;
 
+export const selectAddCommit: (state: StoreState) => IPendingCommitSlice['addCommit'] = (state) =>
+    state.pendingCommitSlice.addCommit;
 export const selectUserCommitActions: (state: StoreState) => {
     addCommit: IPendingCommitSlice['addCommit'];
     removeCommits: IPendingCommitSlice['removeCommits'];


### PR DESCRIPTION
Add commit in commit callback, this assures the user doesnt have to wait to see their pending commit, commits are based on txnHash as their key so should not cause double ups.