### PR TITLE
Fix mobile nav links

### DIFF
--- a/components/Nav/Navbar/MobileMenu/index.tsx
+++ b/components/Nav/Navbar/MobileMenu/index.tsx
@@ -88,25 +88,8 @@ export default (({ account, className }) => {
                                             className={classNames(linkStyles, route === '' ? selectedStyles : '')}
                                             onClick={() => handleRoute('/')}
                                         >
-                                            <img className="mr-2 inline" src={'/img/general/invest.svg'} alt="Trade" />
-                                            Tokens
-                                        </div>
-                                        <div
-                                            className={classNames(linkStyles, route === 'pools' ? selectedStyles : '')}
-                                            onClick={() => handleRoute('/pools')}
-                                        >
                                             <img className="mr-2 inline" src={'/img/general/browse.svg'} alt="Pools" />
                                             Pools
-                                        </div>
-                                        <div
-                                            className={classNames(
-                                                linkStyles,
-                                                route.startsWith('bridge') ? selectedStyles : '',
-                                            )}
-                                            onClick={() => handleRoute('/bridge')}
-                                        >
-                                            <img className="mr-2 inline" src={'/img/general/bridge.svg'} alt="Bridge" />
-                                            Bridge
                                         </div>
                                         <div
                                             className={classNames(
@@ -135,6 +118,27 @@ export default (({ account, className }) => {
                                                 alt="Trading Comp"
                                             />
                                             Trading Comp
+                                        </div>
+
+                                        <div
+                                            className={classNames(
+                                                linkStyles,
+                                                route.startsWith('documentation') ? selectedStyles : '',
+                                            )}
+                                        >
+                                            <a
+                                                href="https://tracer-1.gitbook.io/ppv2-beta-testnet/"
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="my-auto"
+                                            >
+                                                <img
+                                                    className="mr-2 inline"
+                                                    src={'/img/general/browse.svg'}
+                                                    alt="Trading Comp"
+                                                />
+                                                Documentation
+                                            </a>
                                         </div>
                                         <div className="absolute left-0 right-0 bottom-4 mx-auto w-min">
                                             <ThemeSwitcher />

--- a/components/Nav/Navbar/index.tsx
+++ b/components/Nav/Navbar/index.tsx
@@ -68,7 +68,7 @@ export const NavBarContent: React.FC<{
                         className="my-auto"
                     >
                         <li className={classNames(linkStyles)}>
-                            <a className="m-auto">Documentation</a>
+                            <span className="m-auto">Documentation</span>
                         </li>
                     </a>
                 </ul>


### PR DESCRIPTION
-Remove nested "a" tag to remove warning
-Fix mobile nav links

old
<img width="300" alt="Screen Shot 2022-04-11 at 6 00 00 PM" src="https://user-images.githubusercontent.com/97488700/162857494-02fb1f6a-c6c2-4020-bfd4-98360f613c7f.png">
new
<img width="300" alt="Screen Shot 2022-04-11 at 5 59 21 PM" src="https://user-images.githubusercontent.com/97488700/162857483-0f1e21d4-0170-423a-aebd-b4e836970cb0.png">


