### PR TITLE
Add font size variables to theme

### DIFF
--- a/archetypes/Exchange/Gas/index.tsx
+++ b/archetypes/Exchange/Gas/index.tsx
@@ -52,10 +52,10 @@ const GasIconStyled = styled(GasIcon)`
 `;
 
 const Text = styled.span`
-    font-size: 14px;
+    font-size: ${({ theme }) => theme.font.sm};
     font-weight: 600;
 
     @media (min-width: 640px) {
-        font-size: 18px;
+        font-size: ${({ theme: { font } }) => font.lg};
     }
 `;

--- a/archetypes/Exchange/Gas/index.tsx
+++ b/archetypes/Exchange/Gas/index.tsx
@@ -6,6 +6,7 @@ import { networkConfig } from '~/constants/networks';
 import { useGasPrice } from '~/hooks/useGasPrice';
 import GasIcon from '~/public/img/general/gas_icon.svg';
 import { useStore } from '~/store/main';
+import { device, fontSize } from '~/store/ThemeSlice/themes';
 import { selectWalletInfo } from '~/store/Web3Slice';
 
 export default (() => {
@@ -45,17 +46,17 @@ const GasIconStyled = styled(GasIcon)`
     margin-right: 0.2rem;
     transform: scale(0.7);
 
-    @media (min-width: 640px) {
+    @media ${device.sm} {
         margin-right: 0.5rem;
         transform: scale(0.9);
     }
 `;
 
 const Text = styled.span`
-    font-size: ${({ theme }) => theme.font.sm};
+    font-size: ${fontSize.xs};
     font-weight: 600;
 
-    @media (min-width: 640px) {
-        font-size: ${({ theme: { font } }) => font.lg};
+    @media ${device.sm} {
+        font-size: ${fontSize.lg};
     }
 `;

--- a/archetypes/Exchange/Inputs/styles.tsx
+++ b/archetypes/Exchange/Inputs/styles.tsx
@@ -1,9 +1,10 @@
 import styled from 'styled-components';
 import { InputContainer } from '~/components/General/Input';
 import { Input } from '~/components/General/Input/Numeric';
+import { device, fontSize } from '~/store/ThemeSlice/themes';
 
 export const Container = styled.div`
-    @media (min-width: 640px) {
+    @media ${device.sm} {
         display: grid;
         grid-template-columns: 2fr 1fr;
         grid-gap: 15px;
@@ -23,7 +24,7 @@ export const InputContainerStyled = styled(InputContainer)`
 
 export const Label = styled.p`
     margin-bottom: 0.25rem;
-    @media (min-width: 640px) {
+    @media ${device.sm} {
         margin-bottom: 0.5rem;
     }
 `;
@@ -32,17 +33,17 @@ export const InputStyled = styled(Input)`
     width: 60%;
     height: 100%;
     font-weight: 600;
-    font-size: 1rem;
+    font-size: ${fontSize.md};
     line-height: 1.5rem;
 `;
 
 export const Subtext = styled.p<{ showContent: boolean; isAmountValid?: boolean }>`
     display: ${({ showContent }) => (showContent ? 'block' : 'none')};
     color: ${({ isAmountValid, theme }) => (isAmountValid ? '#ef4444' : theme.text)};
-    font-size: 15px;
+    font-size: ${fontSize.sm};
     opacity: 0.7;
 
-    @media (min-width: 640px) {
+    @media ${device.sm} {
         margin-top: 0.5rem;
     }
 `;

--- a/archetypes/Exchange/Summary/styles.tsx
+++ b/archetypes/Exchange/Summary/styles.tsx
@@ -3,10 +3,11 @@ import styled from 'styled-components';
 import { HiddenExpand as UnstyledHiddenExpand } from '~/components/General';
 import Button from '~/components/General/Button';
 import { default as UnstyledTimeLeft } from '~/components/TimeLeft';
+import { device, fontSize } from '~/store/ThemeSlice/themes';
 
 export const HiddenExpand = styled(UnstyledHiddenExpand)<{ showBorder: boolean }>`
     margin-bottom: 2rem !important;
-    font-size: 1rem;
+    font-size: ${fontSize.md};
     line-height: 1.5rem;
     border-width: 1px;
     background-color: ${({ theme }) => theme.background};
@@ -28,12 +29,11 @@ export const Countdown = styled.div`
     top: -1rem;
     left: 1.5rem;
     padding: 0.375rem;
-    font-size: 0.875rem;
     line-height: 1.25rem;
     border-radius: 0.25rem;
     background-color: ${({ theme }) => theme.background};
     z-index: 2;
-    font-size: 15px;
+    font-size: ${fontSize.sm};
     text-transform: capitalize;
 `;
 
@@ -48,7 +48,7 @@ export const TimeLeft = styled(UnstyledTimeLeft)`
 `;
 
 export const SumText = styled.span<{ setColor?: string }>`
-    font-size: 14px;
+    font-size: ${fontSize.xs};
     font-weight: 600;
 
     ${({ setColor }) => {
@@ -63,8 +63,8 @@ export const SumText = styled.span<{ setColor?: string }>`
         }
     }}
 
-    @media (min-width: 640px) {
-        font-size: 15px;
+    @media ${device.sm} {
+        font-size: ${fontSize.sm};
     }
 `;
 

--- a/archetypes/Exchange/TokenSelect/styles.tsx
+++ b/archetypes/Exchange/TokenSelect/styles.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { HiddenExpand, Logo } from '~/components/General';
 import { InnerSearchInput, InputWrapper } from '~/components/General/SearchInput';
 import { Table } from '~/components/General/TWTable';
-import { device } from '~/store/ThemeSlice/themes';
+import { device, fontSize } from '~/store/ThemeSlice/themes';
 
 export const TokenSelectBox = styled.div`
     width: 100%;
@@ -86,7 +86,7 @@ export const TokenSelectTable = styled(Table)`
     width: 100%;
     box-shadow: 0 20px 25px rgba(0, 0, 0, 0.1), 0 10px 10px rgba(0, 0, 0, 0.04);
     font-weight: 600;
-    font-size: 14px;
+    font-size: ${fontSize.xs};
 `;
 
 export const TokenSelectRow = styled.tr<{
@@ -148,14 +148,14 @@ export const TokenSelectCell = styled.td<TokenSelectCell>`
     flex-direction: ${({ hasBalance }) => (hasBalance ? 'column' : 'row')};
     justify-content: ${({ hasLogo }) => (hasLogo ? 'flex-start' : 'center')};
     align-items: center;
-    font-size: 12px;
+    font-size: ${fontSize.xxs};
     svg {
         margin-right: 10px;
     }
     span {
         color: #6b7280;
     }
-    @media (${device.sm}) {
-        font-size: 14px;
+    @media ${device.sm} {
+        font-size: ${fontSize.xs};
     }
 `;

--- a/archetypes/Exchange/index.tsx
+++ b/archetypes/Exchange/index.tsx
@@ -13,6 +13,7 @@ import { usePool } from '~/hooks/usePool';
 import { usePoolInstanceActions } from '~/hooks/usePoolInstanceActions';
 import CloseIcon from '~/public/img/general/close.svg';
 import { useStore } from '~/store/main';
+import { device, fontSize } from '~/store/ThemeSlice/themes';
 import { selectAccount, selectHandleConnect } from '~/store/Web3Slice';
 
 import Gas from './Gas';
@@ -151,18 +152,18 @@ export default styled((({ onClose, className }) => {
     width: 100%;
     justify-content: center;
 
-    @media (min-width: 640px) {
+    @media ${device.sm} {
         margin-top: 1.7rem;
     }
 `;
 
 const Title = styled.h2`
     font-weight: 600;
-    font-size: 20px;
+    font-size: ${fontSize.xl};
     color: ${({ theme }) => theme.text};
     margin-bottom: 15px;
 
-    @media (min-width: 640px) {
+    @media ${device.sm} {
         margin-bottom: 20px;
     }
 `;
@@ -175,7 +176,7 @@ const Close = styled(CloseIcon)`
     height: 0.75rem;
     cursor: pointer;
 
-    @media (min-width: 640px) {
+    @media ${device.sm} {
         right: 4rem;
         top: 3.8rem;
         width: 1rem;
@@ -205,7 +206,7 @@ const DividerRow = styled(Divider)`
 // const CheckboxStyled = styled(Checkbox)`
 //     margin: 25px 0 50px;
 
-//     @media (min-width: 640px) {
+//     @media ${device.sm} {
 //         margin: 29px 0 60px;
 //     }
 // `;

--- a/archetypes/Pools/AddAltPoolModal/styles.tsx
+++ b/archetypes/Pools/AddAltPoolModal/styles.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import CloseIcon from '/public/img/general/close.svg';
 import { SearchInput, InnerSearchInput, SearchIconWrap } from '~/components/General/SearchInput';
+import { device, fontSize } from '~/store/ThemeSlice/themes';
 
 export const Close = styled(CloseIcon)`
     position: absolute;
@@ -10,7 +11,7 @@ export const Close = styled(CloseIcon)`
     height: 0.75rem;
     cursor: pointer;
 
-    @media (min-width: 640px) {
+    @media ${device.sm} {
         right: 4.1rem;
         top: 5rem;
         width: 1rem;
@@ -20,25 +21,25 @@ export const Close = styled(CloseIcon)`
 
 export const Title = styled.h2`
     font-weight: 500;
-    font-size: 20px;
+    font-size: ${fontSize.xl};
     color: ${({ theme }) => theme.text};
     margin: -5px 0 25px;
 
-    @media (min-width: 640px) {
+    @media ${device.sm} {
         margin: 45px 0 37px;
     }
 `;
 
 export const Label = styled.div`
     font-weight: 600;
-    font-size: 16px;
+    font-size: ${fontSize.md};
     color: ${({ theme }) => theme.text};
     margin-bottom: 5px;
 `;
 
 export const Message = styled.div`
     font-weight: 400;
-    font-size: 14px;
+    font-size: ${fontSize.xs};
     color: ${({ theme }) => theme['text-secondary']};
     margin-bottom: 20px;
     text-align: center;

--- a/archetypes/Pools/PoolDetailsModal/index.tsx
+++ b/archetypes/Pools/PoolDetailsModal/index.tsx
@@ -7,6 +7,7 @@ import { Theme } from '~/store/ThemeSlice/themes';
 
 import FollowLink from '/public/img/general/follow-link.svg';
 import Close from '/public/img/general/close.svg';
+import { device, fontSize } from '~/store/ThemeSlice/themes';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
 import { constructExplorerLink } from '~/utils/blockExplorers';
 import { getPriceFeedUrl } from '~/utils/converters';
@@ -101,7 +102,7 @@ const ModalHeader = styled((props: any) => <div className={props.className}>{pro
     justify-content: space-between;
 
     .title {
-        font-size: 24px;
+        font-size: ${fontSize.xxl};
         margin-bottom: -17px;
     }
 
@@ -135,7 +136,7 @@ const CellContent = styled((props: any) => <div className={props.className}>{pro
 
     .name {
         width: 150px;
-        @media (min-width: 768px) {
+        @media ${device.md} {
             width: 195px;
         }
     }

--- a/archetypes/Portfolio/Overview/ConnectWalletBanner/styles.tsx
+++ b/archetypes/Portfolio/Overview/ConnectWalletBanner/styles.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import CTABackground from '~/public/img/cta-bg.svg';
+import { fontSize } from '~/store/ThemeSlice/themes';
 
 export const Container = styled.div`
     overflow: hidden;
@@ -29,7 +30,7 @@ export const Wrapper = styled.div`
 export const Title = styled.div`
     margin-bottom: 1.25rem;
     color: #ffffff;
-    font-size: 1.5rem;
+    font-size: ${fontSize.xxl};
     line-height: 2rem;
     text-align: center;
 `;

--- a/archetypes/Portfolio/Overview/EscrowTable/styles.tsx
+++ b/archetypes/Portfolio/Overview/EscrowTable/styles.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import Button from '~/components/General/Button';
 import { TableRowCell } from '~/components/General/TWTable';
+import { fontSize } from '~/store/ThemeSlice/themes';
 import { TokenType as TokenTypeEnum } from '../state';
 
 export const Pool = styled.tr`
@@ -15,7 +16,7 @@ export const Pool = styled.tr`
 export const PoolName = styled.span`
     font-style: normal;
     font-weight: bold;
-    font-size: 18px;
+    font-size: ${fontSize.lg};
     line-height: 150%;
     margin-left: 1rem;
     white-space: nowrap;
@@ -24,7 +25,7 @@ export const PoolName = styled.span`
 export const InfoLabel = styled.div`
     font-style: normal;
     font-weight: 600;
-    font-size: 16px;
+    font-size: ${fontSize.md};
     line-height: 150%;
     white-space: nowrap;
 
@@ -34,7 +35,7 @@ export const InfoLabel = styled.div`
 export const Value = styled.div`
     font-style: normal;
     font-weight: bold;
-    font-size: 16px;
+    font-size: ${fontSize.md};
     line-height: 150%;
 `;
 
@@ -94,11 +95,10 @@ export const DropdownArrow = styled.img`
 
 // ROWS
 export const InnerText = styled.div`
-    /* text-base/font-normal */
     font-family: Source Sans Pro, sans-serif;
     font-style: normal;
     font-weight: normal;
-    font-size: 16px;
+    font-size: ${fontSize.md};
     line-height: 150%;
 
     &.sub-text {

--- a/archetypes/Portfolio/Overview/HelpCard/styles.tsx
+++ b/archetypes/Portfolio/Overview/HelpCard/styles.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Theme } from '~/store/ThemeSlice/themes';
+import { fontSize } from '~/store/ThemeSlice/themes';
 
 export const GuideCard = styled.div`
     padding: 1.5rem 1rem;
@@ -17,7 +18,7 @@ export const GuideCard = styled.div`
 `;
 
 export const GuideCardTitle = styled.div`
-    font-size: 1.5rem;
+    font-size: ${fontSize.xxl};
     line-height: 2rem;
     font-weight: 600;
     margin-bottom: 0.75rem;
@@ -28,7 +29,7 @@ export const Badge = styled.div`
     padding: 0.25rem 0.75rem;
     margin-bottom: 0.75rem;
     color: #ffffff;
-    font-size: 0.875rem;
+    font-size: ${fontSize.xs};
     line-height: 1.25rem;
     width: min-content;
     border-radius: 0.25rem;

--- a/archetypes/Portfolio/Overview/HoldingsTable/styles.tsx
+++ b/archetypes/Portfolio/Overview/HoldingsTable/styles.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { SearchInput as UnstyledSearchInput } from '~/components/General/SearchInput';
+import { device, fontSize } from '~/store/ThemeSlice/themes';
 
 export const Container = styled.div`
     border-radius: 0.75rem;
@@ -9,7 +10,7 @@ export const Container = styled.div`
 `;
 
 export const Title = styled.div`
-    font-size: 1.5rem;
+    font-size: ${fontSize.xxl};
     line-height: 2rem;
     font-weight: 600;
     margin: 1rem 0;
@@ -23,7 +24,7 @@ export const Text = styled.div`
 export const Wrapper = styled.div`
     white-space: nowrap;
 
-    @media (min-width: 640px) {
+    @media ${device.sm} {
         display: flex;
         justify-content: space-between;
     }
@@ -39,7 +40,7 @@ export const Actions = styled.div`
     &:first-child {
         margin-right: 0.5rem;
 
-        @media (min-width: 640px) {
+        @media ${device.sm} {
             margin-right: 1.25rem;
         }
     }

--- a/archetypes/Portfolio/Overview/TradeOverviewBanner/styles.tsx
+++ b/archetypes/Portfolio/Overview/TradeOverviewBanner/styles.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { device, fontSize } from '~/store/ThemeSlice/themes';
 
 export const Banner = styled.div<{ showFullWidth?: boolean }>`
     padding: 1.25rem;
@@ -8,7 +9,7 @@ export const Banner = styled.div<{ showFullWidth?: boolean }>`
 `;
 
 export const Text = styled.div<{ isBold?: boolean; showOpacity?: boolean }>`
-    font-size: 1.5rem;
+    font-size: ${fontSize.xxl};
     line-height: 2rem;
     margin: 0;
     font-weight: ${({ isBold }) => (isBold ? '700' : '600')};
@@ -16,7 +17,7 @@ export const Text = styled.div<{ isBold?: boolean; showOpacity?: boolean }>`
 `;
 
 export const BannerContent = styled.div`
-    @media (min-width: 768px) {
+    @media ${device.md} {
         display: grid;
         grid-template-columns: repeat(3, minmax(0, 1fr));
         gap: 0.75rem;
@@ -33,6 +34,6 @@ export const Card = styled.div`
 export const CardTitle = styled.div`
     font-weight: 700;
     opacity: 0.5;
-    font-size: 16px;
+    font-size: ${fontSize.md};
     color: #6b7280;
 `;

--- a/archetypes/Portfolio/Overview/styles.tsx
+++ b/archetypes/Portfolio/Overview/styles.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Container as GeneralContainer } from '~/components/General/Container';
+import { device } from '~/store/ThemeSlice/themes';
 
 export const Container = styled(GeneralContainer)`
     margin-top: 20px;
@@ -13,7 +14,7 @@ export const Wrapper = styled.div<{ isFullWidth?: boolean }>`
     grid-template-columns: minmax(0, 1fr);
     grid-gap: 30px;
 
-    @media (min-width: 1280px) {
+    @media ${device.xl} {
         display: grid;
         grid-template-columns: ${({ isFullWidth }) =>
             isFullWidth ? 'minmax(0, 1fr)' : 'minmax(0, 2fr) minmax(0, 1fr)'};
@@ -24,7 +25,7 @@ export const Banner = styled.div`
     display: grid;
     grid-template-columns: minmax(0, 1fr);
     gap: 30px;
-    @media (min-width: 768px) {
+    @media ${device.md} {
         grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 `;

--- a/components/General/Button/ExchangeButton.tsx
+++ b/components/General/Button/ExchangeButton.tsx
@@ -5,6 +5,7 @@ import { CommitActionEnum, BalanceTypeEnum, CommitEnum } from '@tracer-protocol/
 import Pool from '@tracer-protocol/pools-js/entities/pool';
 import Button from '~/components/General/Button';
 import { SwapAction, SwapState } from '~/context/SwapContext';
+import { fontSize } from '~/store/ThemeSlice/themes';
 import { AggregateBalances } from '~/types/pools';
 
 type ExchangeButton = {
@@ -125,7 +126,7 @@ export default ExchangeButton;
 
 const Text = styled.p`
     margin-top: 0.5rem;
-    font-size: 0.875rem;
+    font-size: ${fontSize.xs};
     line-height: 1.25rem;
     text-align: center;
     opacity: 0.7;

--- a/components/General/Checkbox/index.tsx
+++ b/components/General/Checkbox/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Theme } from '~/store/ThemeSlice/themes';
+import { fontSize } from '~/store/ThemeSlice/themes';
 
 export default (({ onClick, isChecked, className, label, subtext }) => {
     return (
@@ -99,7 +100,7 @@ const Checkmark = styled.span<{ isChecked: boolean }>`
 `;
 
 const Subtext = styled.p`
-    font-size: 12px;
+    font-size: ${fontSize.xxs};
     margin-left: 30px;
     color: ${({ theme }) => {
         switch (theme.theme) {

--- a/components/General/Max/index.tsx
+++ b/components/General/Max/index.tsx
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
 import { Theme } from '~/store/ThemeSlice/themes';
+import { fontSize } from '~/store/ThemeSlice/themes';
 
 const Max = styled.div`
     cursor: pointer;
     text-transform: uppercase;
     font-weight: bold;
-    font-size: 16px;
+    font-size: ${fontSize.md};
     line-height: 150%;
     color: ${({ theme }) => (theme.theme === Theme.Light ? '#2A2AC7' : '#fff')};
     &:hover {

--- a/components/General/Notification/Icon.tsx
+++ b/components/General/Notification/Icon.tsx
@@ -7,9 +7,10 @@ import Error from '~/public/img/notifications/error.svg';
 import Success from '~/public/img/notifications/success.svg';
 import Warning from '~/public/img/notifications/warning.svg';
 import { Theme } from '~/store/ThemeSlice/themes';
+import { fontSize } from '~/store/ThemeSlice/themes';
 
 const StyledIcon = styled(Icon)`
-    font-size: 2rem; /* 32px */
+    font-size: ${fontSize.xxxl};
 
     &.loading {
         color: ${({ theme: { theme } }) => {
@@ -24,7 +25,7 @@ const StyledIcon = styled(Icon)`
 `;
 
 const StyledInfo = styled(InfoCircleFilled)`
-    font-size: 1.5rem; /* 24px */
+    font-size: ${fontSize.xxl};
 `;
 
 export const NotificationIcon = ({ type }: { type: ToastOptions['type'] }): JSX.Element => {

--- a/components/General/Notification/Notification.tsx
+++ b/components/General/Notification/Notification.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Theme } from '~/store/ThemeSlice/themes';
+import { fontSize } from '~/store/ThemeSlice/themes';
 import { NotificationIcon } from './Icon';
 
 type InjectedProps = {
@@ -30,7 +31,7 @@ const Content = styled.div`
     line-height: 1.4;
     width: 100%;
     word-break: break-word;
-    font-size: 1rem;
+    font-size: ${fontSize.md};
     margin-top: 0.5rem;
     margin-left: calc(15px + 24px); // Title margin + width of icon
 

--- a/components/General/SearchInput/index.tsx
+++ b/components/General/SearchInput/index.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react';
 import { SearchOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
 import { device } from '~/store/ThemeSlice/themes';
+import { fontSize } from '~/store/ThemeSlice/themes';
 
 interface SearchInputProps {
     className?: string;
@@ -58,8 +59,7 @@ export const InnerSearchInput = styled.input`
     }
 
     @media (${device.sm}) {
-        // TODO create font-size css variables
-        font-size: 0.875rem; /* 14px */
+        font-size: ${fontSize.xs};
         line-height: 1.25rem; /* 20px */
     }
 `;

--- a/components/General/TWButtonGroup/index.tsx
+++ b/components/General/TWButtonGroup/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import TooltipSelector, { TooltipKeys } from '~/components/Tooltips/TooltipSelector';
+import { fontSize } from '~/store/ThemeSlice/themes';
 import { classNames } from '~/utils/helpers';
 
 // the difference here is the bg on unselected
@@ -140,7 +141,7 @@ const NewCallOut = styled.span`
     z-index: 11;
     color: #fff;
     font-weight: 700;
-    font-size: 10px;
+    font-size: ${fontSize.xxxs};
     border-radius: 4px;
     width: 41px;
     height: 17px;

--- a/components/General/TWTable/index.tsx
+++ b/components/General/TWTable/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Theme } from '~/store/ThemeSlice/themes';
+import { fontSize } from '~/store/ThemeSlice/themes';
 import { classNames } from '~/utils/helpers';
 
 export const Table: React.FC<{ showDivider?: boolean; className?: string }> = ({
@@ -50,7 +51,7 @@ export const TableHeaderCell = styled.th.attrs((props) => ({
     size?: Size;
     twAlign?: Align;
 }>`
-    font-size: 0.75rem; /* 12px */
+    font-size: ${fontSize.xxs};
     line-height: 1rem; /* 16px */
     text-align: left;
     font-weight: 500;

--- a/components/General/index.tsx
+++ b/components/General/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { device, fontSize } from '~/store/ThemeSlice/themes';
 import { Children } from '~/types/general';
 import { classNames } from '~/utils/helpers';
 
@@ -22,7 +23,7 @@ export const Section: React.FC<SProps> = styled(
     display: grid;
     grid-template-columns: 3fr 1fr;
     width: 100%;
-    font-size: 14px;
+    font-size: ${fontSize.xs};
     line-height: 18px;
     box-sizing: border-box;
     color: ${({ theme }) => theme['text-secondary']};
@@ -39,7 +40,7 @@ export const Section: React.FC<SProps> = styled(
         padding-bottom: 3px;
     }
 
-    @media (min-width: 640px) {
+    @media ${device.sm} {
         margin-bottom: 3px;
     }
 `;
@@ -55,21 +56,21 @@ const Label = styled.div<{ showSectionDetails: boolean }>`
                 margin-left: 0.75rem;
                 margin-bottom: 0;
                 max-width: 140px;
-                font-size: 12px;
+                font-size: ${fontSize.xxs};
                 line-height: 18px;
                 font-weight: 400;
             `;
         }
     }}
 
-    @media (min-width: 640px) {
-        font-size: 15px;
+    @media ${device.sm} {
+        font-size: ${fontSize.sm};
 
         ${({ showSectionDetails }) => {
             if (showSectionDetails) {
                 return `
                     max-width: 100%;
-                    font-size: 14px;
+                    font-size: ${fontSize.xs};
                 `;
             }
         }}
@@ -80,11 +81,11 @@ const Content = styled.span`
     width: 100%;
     text-align: right;
     padding-left: 0.25rem;
-    font-size: 12px;
+    font-size: ${fontSize.xxs};
     white-space: nowrap;
 
-    @media (min-width: 640px) {
-        font-size: 14px;
+    @media ${device.sm} {
+        font-size: ${fontSize.xs};
     }
 `;
 

--- a/components/Nav/Navbar/AccountDropdown/styles.tsx
+++ b/components/Nav/Navbar/AccountDropdown/styles.tsx
@@ -1,11 +1,11 @@
 import { CopyOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
 import { Logo } from '~/components/General';
-import { device } from '~/store/ThemeSlice/themes';
+import { device, fontSize } from '~/store/ThemeSlice/themes';
 
 export const ArbitrumLogo = styled(Logo)`
     display: inline;
-    font-size: 1.125rem; /* 18px */
+    font-size: ${fontSize.lg};
     line-height: 1.75rem; /* 28px */
     margin-top: auto;
     margin-bottom: auto;
@@ -19,7 +19,7 @@ export const ViewOnArbiscanOption = styled.a`
         background: ${({ theme }) => theme['button-bg-hover']};
     }
 
-    font-size: 0.875rem; /* 14px */
+    font-size: ${fontSize.xs};
     line-height: 1.25rem; /* 20px */
 `;
 
@@ -35,7 +35,7 @@ export const LogoutButton = styled.button`
     padding: 0.5rem 1rem;
     margin: 0.25rem;
     font-weight: 500;
-    font-size: 0.875rem; /* 14px */
+    font-size: ${fontSize.xs};
     line-height: 1.25rem; /* 20px */
     background-color: #2563eb;
     color: #fff;
@@ -49,7 +49,7 @@ export const LogoutButton = styled.button`
 export const CopyAccount = styled.div`
     display: flex;
     padding: 0.75rem 1rem 0.5rem 1rem;
-    font-size: 0.875rem; /* 14px */
+    font-size: ${fontSize.xs};
     line-height: 1.25rem; /* 20px */
 `;
 

--- a/components/Nav/Navbar/NetworkDropdown.tsx
+++ b/components/Nav/Navbar/NetworkDropdown.tsx
@@ -8,13 +8,14 @@ import TWPopup from '~/components/General/TWPopup';
 import { networkConfig } from '~/constants/networks';
 import Error from '~/public/img/notifications/error.svg';
 import { useStore } from '~/store/main';
+import { fontSize } from '~/store/ThemeSlice/themes';
 import { selectWeb3Info } from '~/store/Web3Slice';
 import { switchNetworks } from '~/utils/rpcMethods';
 import { isSupportedNetwork } from '~/utils/supportedNetworks';
 
 const Option = styled.option`
     padding: 0.5rem 1rem;
-    font-size: 14px;
+    font-size: ${fontSize.xs};
     cursor: pointer;
     text-align: left;
 

--- a/components/Nav/Navbar/VersionToggle.tsx
+++ b/components/Nav/Navbar/VersionToggle.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { device, fontSize } from '~/store/ThemeSlice/themes';
 
 export default (({ hideOnDesktop }) => (
     <VersionToggle hideOnDesktop={hideOnDesktop}>
@@ -26,7 +27,7 @@ const VersionToggle = styled.span<{ hideOnDesktop?: boolean }>`
     font-weight: 600;
     letter-spacing: 0.115em;
 
-    @media (min-width: 1024px) {
+    @media ${device.lg} {
         display: ${({ hideOnDesktop }) => (hideOnDesktop ? 'none' : 'grid')};
         margin: 10px 0 10px 10px;
     }
@@ -57,7 +58,7 @@ const V2 = styled.span`
 const New = styled.span`
     background-color: #3535dc;
     color: #fff;
-    font-size: 10px;
+    font-size: ${fontSize.xxxs};
     font-weight: 700;
     border-radius: 3px;
     padding: 0 4px;

--- a/components/Nav/Navbar/WalletIcon.tsx
+++ b/components/Nav/Navbar/WalletIcon.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import shallow from 'zustand/shallow';
 import { useStore } from '~/store/main';
+import { fontSize } from '~/store/ThemeSlice/themes';
 import { selectWalletInfo } from '~/store/Web3Slice';
 import Identicon from './Identicon';
 
@@ -9,7 +10,7 @@ const WalletIconImage = styled.img`
     display: inline;
     height: 20px;
     margin: auto 0;
-    font-size: 1.125rem; /* 18px */
+    font-size: ${fontSize.lg};
     line-height: 1.75rem; /* 28px */
 `;
 

--- a/context/ThemeContext/index.tsx
+++ b/context/ThemeContext/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { useStore } from '~/store/main';
 import { selectSetTheme, selectTheme } from '~/store/ThemeSlice';
-import { Theme, themes } from '~/store/ThemeSlice/themes';
+import { Theme, themes, font } from '~/store/ThemeSlice/themes';
 
 export const StyledThemeProvider = ({ children }: { children: React.ReactNode }): JSX.Element => {
     const theme = useStore(selectTheme);
@@ -15,5 +15,14 @@ export const StyledThemeProvider = ({ children }: { children: React.ReactNode })
         }
     }, []);
 
-    return <ThemeProvider theme={themes[theme]}>{children}</ThemeProvider>;
+    return (
+        <ThemeProvider
+            theme={{
+                ...themes[theme],
+                font,
+            }}
+        >
+            {children}
+        </ThemeProvider>
+    );
 };

--- a/context/ThemeContext/index.tsx
+++ b/context/ThemeContext/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { useStore } from '~/store/main';
 import { selectSetTheme, selectTheme } from '~/store/ThemeSlice';
-import { Theme, themes, font } from '~/store/ThemeSlice/themes';
+import { Theme, themes } from '~/store/ThemeSlice/themes';
 
 export const StyledThemeProvider = ({ children }: { children: React.ReactNode }): JSX.Element => {
     const theme = useStore(selectTheme);
@@ -15,14 +15,5 @@ export const StyledThemeProvider = ({ children }: { children: React.ReactNode })
         }
     }, []);
 
-    return (
-        <ThemeProvider
-            theme={{
-                ...themes[theme],
-                font,
-            }}
-        >
-            {children}
-        </ThemeProvider>
-    );
+    return <ThemeProvider theme={themes[theme]}>{children}</ThemeProvider>;
 };

--- a/store/ThemeSlice/themes.ts
+++ b/store/ThemeSlice/themes.ts
@@ -112,10 +112,11 @@ export const themes: Record<
     },
 };
 
-export const font = {
-    xxs: '0.625rem', // 10px
-    xs: '0.75rem', // 12px
-    sm: '0.875', // 14px
+export const fontSize = {
+    xxxs: '0.625rem', // 10px
+    xxs: '0.75rem', // 12px
+    xs: '0.875', // 14px
+    sm: '0.938', // 15px
     md: '1rem', // 16px
     lg: '1.125rem', // 18px
     xl: '1.25rem', // 20px

--- a/store/ThemeSlice/themes.ts
+++ b/store/ThemeSlice/themes.ts
@@ -112,6 +112,17 @@ export const themes: Record<
     },
 };
 
+export const font = {
+    xxs: '0.625rem', // 10px
+    xs: '0.75rem', // 12px
+    sm: '0.875', // 14px
+    md: '1rem', // 16px
+    lg: '1.125rem', // 18px
+    xl: '1.25rem', // 20px
+    xxl: '1.5rem', // 24px
+    xxxl: '2rem', // 32px
+};
+
 const size = {
     sm: '640px',
     md: '768px',


### PR DESCRIPTION
Add font-size consistency

I like having the sizes available from the theme obj but don't really care for the implementation.

```font-size: ${({ theme }) => theme.font.sm};
font-size: ${({ theme: { font } }) => font.lg};

we can also spread the font object and implement
font-size: ${({ theme }) => theme.fontLg};
```

We could continue using global variables since its a cleaner implementation imo.