### PR TITLE
V2/update theme styles

### DIFF
--- a/archetypes/Exchange/Inputs/styles.tsx
+++ b/archetypes/Exchange/Inputs/styles.tsx
@@ -17,7 +17,7 @@ export const Wrapper = styled.div<{ hasMargin?: boolean }>`
 
 export const InputContainerStyled = styled(InputContainer)`
     width: 100%;
-    border-color: ${({ theme }) => theme['border']};
+    border-color: ${({ theme }) => theme.border.primary};
     border-radius: 7px;
 `;
 
@@ -38,7 +38,7 @@ export const InputStyled = styled(Input)`
 
 export const Subtext = styled.p<{ showContent: boolean; isAmountValid?: boolean }>`
     display: ${({ showContent }) => (showContent ? 'block' : 'none')};
-    color: ${({ isAmountValid, theme }) => (isAmountValid ? '#ef4444' : theme.text)};
+    color: ${({ isAmountValid, theme }) => (isAmountValid ? '#ef4444' : theme.fontColor.primary)};
     font-size: 15px;
     opacity: 0.7;
 

--- a/archetypes/Exchange/Summary/styles.tsx
+++ b/archetypes/Exchange/Summary/styles.tsx
@@ -9,8 +9,8 @@ export const HiddenExpand = styled(UnstyledHiddenExpand)<{ showBorder: boolean }
     font-size: 1rem;
     line-height: 1.5rem;
     border-width: 1px;
-    background-color: ${({ theme }) => theme.background};
-    border-color: ${({ showBorder, theme }) => (showBorder ? theme['border-secondary'] : 'transparent')};
+    background-color: ${({ theme }) => theme.background.primary};
+    border-color: ${({ showBorder, theme }) => (showBorder ? theme.border.secondary : 'transparent')};
 `;
 
 export const Wrapper = styled.div`
@@ -31,7 +31,7 @@ export const Countdown = styled.div`
     font-size: 0.875rem;
     line-height: 1.25rem;
     border-radius: 0.25rem;
-    background-color: ${({ theme }) => theme.background};
+    background-color: ${({ theme }) => theme.background.primary};
     z-index: 2;
     font-size: 15px;
     text-transform: capitalize;
@@ -43,8 +43,8 @@ export const TimeLeft = styled(UnstyledTimeLeft)`
     margin-left: 0.375rem;
     border-radius: 0.5rem;
     border-width: 1px;
-    background-color: ${({ theme }) => theme['button-bg']};
-    border-color: ${({ theme }) => theme['border-secondary']};
+    background-color: ${({ theme }) => theme.button.bg};
+    border-color: ${({ theme }) => theme.border.secondary};
 `;
 
 export const SumText = styled.span<{ setColor?: string }>`
@@ -75,7 +75,7 @@ export const Divider = styled.hr`
 export const ShowDetailsButton = styled(Button)`
     width: calc(100% + 2rem);
     margin: 23px -1rem 0;
-    background-color: ${({ theme }) => theme['border-secondary']} !important;
+    background-color: ${({ theme }) => theme.border.secondary} !important;
     border-top-left-radius: 0 !important;
     border-top-right-radius: 0 !important;
     height: 30px;
@@ -84,7 +84,7 @@ export const ShowDetailsButton = styled(Button)`
     svg {
         margin: 0 auto;
         path {
-            fill: ${({ theme }) => theme.text} !important;
+            fill: ${({ theme }) => theme.fontColor.primary} !important;
         }
     }
 

--- a/archetypes/Exchange/TokenSelect/styles.tsx
+++ b/archetypes/Exchange/TokenSelect/styles.tsx
@@ -7,7 +7,7 @@ import { device } from '~/store/ThemeSlice/themes';
 
 export const TokenSelectBox = styled.div`
     width: 100%;
-    background: ${({ theme }) => theme['background-secondary']};
+    background: ${({ theme }) => theme.background.secondary};
     height: 220px;
     box-shadow: 0px 20px 25px rgba(0, 0, 0, 0.1), 0px 10px 10px rgba(0, 0, 0, 0.04);
     border-radius: 7px;
@@ -116,7 +116,7 @@ export const TokenSelectRow = styled.tr<{
 `;
 
 export const TokenSelectHead = styled.thead`
-    background-color: ${({ theme }) => theme['border-secondary']};
+    background-color: ${({ theme }) => theme.border.secondary};
     padding: 1rem;
     text-align: center;
     border-radius: 7px;
@@ -131,12 +131,12 @@ export const HeaderCell = styled.th`
         right: 0;
         height: 70%;
         width: 1px;
-        background: ${({ theme }) => (theme.isDark ? '' : theme.text)};
+        background: ${({ theme }) => (theme.isDark ? '' : theme.fontColor.primary)};
     }
 `;
 
 export const TokenSelectBody = styled.tbody`
-    background-color: ${({ theme }) => (theme.isDark ? theme['button-bg'] : theme.backgroud)};
+    background-color: ${({ theme }) => (theme.isDark ? theme.button.bg : theme.backgroud)};
 `;
 
 interface TokenSelectCell {

--- a/archetypes/Exchange/TokenSelect/styles.tsx
+++ b/archetypes/Exchange/TokenSelect/styles.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { HiddenExpand, Logo } from '~/components/General';
 import { InnerSearchInput, InputWrapper } from '~/components/General/SearchInput';
 import { Table } from '~/components/General/TWTable';
-import { device } from '~/store/ThemeSlice/themes';
+import { device, Theme } from '~/store/ThemeSlice/themes';
 
 export const TokenSelectBox = styled.div`
     width: 100%;
@@ -107,7 +107,14 @@ export const TokenSelectRow = styled.tr<{
         right: 0;
         height: 40%;
         width: 1px;
-        background: ${({ theme }) => (theme.isDark ? '#F9FAFB' : '#E5E7EB')};
+        background: ${({ theme }) => {
+            switch (theme.theme) {
+                case Theme.Light:
+                    return '#E5E7EB';
+                default:
+                    return '#F9FAFB';
+            }
+        }};
     }
 
     &:hover {
@@ -131,12 +138,12 @@ export const HeaderCell = styled.th`
         right: 0;
         height: 70%;
         width: 1px;
-        background: ${({ theme }) => (theme.isDark ? '' : theme.fontColor.primary)};
+        background: ${({ theme }) => theme.fontColor.primary};
     }
 `;
 
 export const TokenSelectBody = styled.tbody`
-    background-color: ${({ theme }) => (theme.isDark ? theme.button.bg : theme.backgroud)};
+    background-color: ${({ theme }) => theme.button.bg};
 `;
 
 interface TokenSelectCell {

--- a/archetypes/Exchange/TokenSelect/styles.tsx
+++ b/archetypes/Exchange/TokenSelect/styles.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { HiddenExpand, Logo } from '~/components/General';
 import { InnerSearchInput, InputWrapper } from '~/components/General/SearchInput';
 import { Table } from '~/components/General/TWTable';
-import { device, Theme } from '~/store/ThemeSlice/themes';
+import { Theme } from '~/store/ThemeSlice/themes';
 
 export const TokenSelectBox = styled.div`
     width: 100%;
@@ -25,7 +25,7 @@ export const TokenSelectDropdown = styled(HiddenExpand)`
     padding: 0 1rem;
     margin-left: -1rem;
 
-    @media ${device.sm} {
+    @media ${({ theme }) => theme.device.sm} {
         padding: 0 4rem;
         margin-left: -4rem;
     }
@@ -162,7 +162,7 @@ export const TokenSelectCell = styled.td<TokenSelectCell>`
     span {
         color: #6b7280;
     }
-    @media (${device.sm}) {
+    @media (${({ theme }) => theme.device.sm}) {
         font-size: 14px;
     }
 `;

--- a/archetypes/Exchange/index.tsx
+++ b/archetypes/Exchange/index.tsx
@@ -159,7 +159,7 @@ export default styled((({ onClose, className }) => {
 const Title = styled.h2`
     font-weight: 600;
     font-size: 20px;
-    color: ${({ theme }) => theme.text};
+    color: ${({ theme }) => theme.fontColor.primary};
     margin-bottom: 15px;
 
     @media (min-width: 640px) {
@@ -198,7 +198,7 @@ const TWButtonGroupStyled = styled(TWButtonGroup)`
 
 const DividerRow = styled(Divider)`
     margin: 30px 0;
-    border-color: ${({ theme }) => theme['border-secondary']};
+    border-color: ${({ theme }) => theme.border.secondary};
 `;
 
 // TODO: dependent on auto-claim feature

--- a/archetypes/Pools/AddAltPoolModal/styles.tsx
+++ b/archetypes/Pools/AddAltPoolModal/styles.tsx
@@ -21,7 +21,7 @@ export const Close = styled(CloseIcon)`
 export const Title = styled.h2`
     font-weight: 500;
     font-size: 20px;
-    color: ${({ theme }) => theme.text};
+    color: ${({ theme }) => theme.fontColor.primary};
     margin: -5px 0 25px;
 
     @media (min-width: 640px) {
@@ -32,14 +32,14 @@ export const Title = styled.h2`
 export const Label = styled.div`
     font-weight: 600;
     font-size: 16px;
-    color: ${({ theme }) => theme.text};
+    color: ${({ theme }) => theme.fontColor.primary};
     margin-bottom: 5px;
 `;
 
 export const Message = styled.div`
     font-weight: 400;
     font-size: 14px;
-    color: ${({ theme }) => theme['text-secondary']};
+    color: ${({ theme }) => theme.fontColor.secondary};
     margin-bottom: 20px;
     text-align: center;
 `;

--- a/archetypes/Pools/FilterSelects/styles.tsx
+++ b/archetypes/Pools/FilterSelects/styles.tsx
@@ -32,7 +32,7 @@ export const Content = styled.div`
     flex-direction: column;
     border-radius: 7px;
     gap: 20px;
-    background-color: ${({ theme }) => theme['background-secondary']};
+    background-color: ${({ theme }) => theme.background.secondary};
     box-shadow: ${({ theme }) => {
         switch (theme.theme) {
             case Theme.Light:
@@ -71,13 +71,13 @@ export const FilterPopup = styled(TWPopup)`
     position: relative;
 
     .action-button {
-        border: 1px ${({ theme }) => theme.border} solid !important;
+        border: 1px ${({ theme }) => theme.border.primary} solid !important;
         font-size: 16px !important;
         font-weight: 400 !important;
         color: rgb(156 163 175);
         display: inline-flex;
         padding: 0.67rem 1rem;
-        background-color: ${({ theme }) => theme['button-bg']};
+        background-color: ${({ theme }) => theme.button.bg};
         white-space: nowrap;
         display: inline-flex;
         justify-content: center;
@@ -86,7 +86,7 @@ export const FilterPopup = styled(TWPopup)`
         box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
 
         &:hover {
-            background-color: ${({ theme }) => theme['button-bg-hover']};
+            background-color: ${({ theme }) => theme.button.hover};
         }
     }
 
@@ -103,13 +103,13 @@ export const FilterIcon = styled(FilterToggleIcon)`
 export const Heading = styled.h3`
     margin-bottom: 0.25rem;
     font-weight: 500;
-    color: ${({ theme }) => theme.text};
+    color: ${({ theme }) => theme.fontColor.primary};
 `;
 
 export const Text = styled.div`
     margin-bottom: 0.7rem;
     font-weight: 500;
-    color: ${({ theme }) => theme.text};
+    color: ${({ theme }) => theme.fontColor.primary};
     font-size: 12px;
 `;
 

--- a/archetypes/Pools/FilterSelects/styles.tsx
+++ b/archetypes/Pools/FilterSelects/styles.tsx
@@ -6,7 +6,6 @@ import TWPopup from '~/components/General/TWPopup';
 import ArrowDownIcon from '~/public/img/general/arrow-circle-down.svg';
 import FilterToggleIcon from '~/public/img/general/filters.svg';
 import { Theme } from '~/store/ThemeSlice/themes';
-import { device } from '~/store/ThemeSlice/themes';
 
 export const Container = styled(UnstyledContainer)`
     display: flex;
@@ -17,11 +16,11 @@ export const Container = styled(UnstyledContainer)`
     padding: 0;
     max-width: 720px;
 
-    @media ${device.md} {
+    @media ${({ theme }) => theme.device.md} {
         flex-direction: row;
     }
 
-    @media ${device.lg} {
+    @media ${({ theme }) => theme.device.lg} {
         align-items: flex-end;
     }
 `;
@@ -61,7 +60,7 @@ export const Wrapper = styled.div`
 export const SearchInput = styled(UnstyledSearchInput)`
     width: 100%;
 
-    @media ${device.md} {
+    @media ${({ theme }) => theme.device.md} {
         width: 50%;
     }
 `;
@@ -90,7 +89,7 @@ export const FilterPopup = styled(TWPopup)`
         }
     }
 
-    @media ${device.md} {
+    @media ${({ theme }) => theme.device.md} {
         width: 50%;
     }
 `;

--- a/archetypes/Pools/styles.tsx
+++ b/archetypes/Pools/styles.tsx
@@ -2,12 +2,11 @@ import styled from 'styled-components';
 import { default as UnstyledButton } from '~/components/General/Button';
 import { Container as UnstyledContainer } from '~/components/General/Container';
 import { default as UnstyledLoading } from '~/components/General/Loading';
-import { device } from '~/store/ThemeSlice/themes';
 
 export const Header = styled.div`
     margin-bottom: 2rem;
 
-    @media ${device.lg} {
+    @media ${({ theme }) => theme.device.lg} {
         display: flex;
         gap: 20px;
     }
@@ -27,7 +26,7 @@ export const SubHeading = styled.div`
     line-height: 1.25rem;
     font-weight: 300;
 
-    @media ${device.lg} {
+    @media ${({ theme }) => theme.device.lg} {
         margin-bottom: 0;
     }
 `;
@@ -56,10 +55,10 @@ export const DataRow = styled.div`
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
     background-color: ${({ theme }) => theme.background.primary};
 
-    @media ${device.sm} {
+    @media ${({ theme }) => theme.device.sm} {
         border-radius: 1rem;
     }
-    @media ${device.md} {
+    @media ${({ theme }) => theme.device.md} {
         padding: 2rem;
         border-radius: 1.5rem;
     }
@@ -99,24 +98,24 @@ export const AltPoolActions = styled.div`
     flex-direction: column;
     gap: 20px;
 
-    @media ${device.sm} {
+    @media ${({ theme }) => theme.device.sm} {
         gap: 0;
         flex-direction: row;
     }
 `;
 
 export const Button = styled(UnstyledButton)<{ disabled?: boolean }>`
-    @media ${device.sm} {
+    @media ${({ theme }) => theme.device.sm} {
         max-width: 220px;
     }
 
-    ${({ disabled }) => {
+    ${({ disabled, theme }) => {
         if (disabled) {
             return `
                 cursor: not-allowed; 
                 opacity: 0.5; 
 
-                @media ${device.sm} {
+                @media ${theme.device.sm} {
                     margin-left: 1.25rem; 
                 }
             `;

--- a/archetypes/Pools/styles.tsx
+++ b/archetypes/Pools/styles.tsx
@@ -14,7 +14,7 @@ export const Header = styled.div`
 `;
 
 export const Heading = styled.h1`
-    color: ${({ theme }) => theme.text};
+    color: ${({ theme }) => theme.fontColor.primary};
     margin: 2rem 0 0.5rem;
     font-size: 1.875rem;
     line-height: 2.25rem;
@@ -54,7 +54,7 @@ export const DataRow = styled.div`
     margin-bottom: 2.5rem;
     border-radius: 0.25rem;
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-    background-color: ${({ theme }) => theme.background};
+    background-color: ${({ theme }) => theme.background.primary};
 
     @media ${device.sm} {
         border-radius: 1rem;

--- a/archetypes/Portfolio/Overview/EscrowTable/styles.tsx
+++ b/archetypes/Portfolio/Overview/EscrowTable/styles.tsx
@@ -4,8 +4,8 @@ import { TableRowCell } from '~/components/General/TWTable';
 import { TokenType as TokenTypeEnum } from '../state';
 
 export const Pool = styled.tr`
-    color: ${({ theme }) => theme.text};
-    background: ${({ theme }) => theme['background-secondary']};
+    color: ${({ theme }) => theme.fontColor.primary};
+    background: ${({ theme }) => theme.background.secondary};
     display: flex;
     border-radius: 10px;
     overflow-x: auto;

--- a/archetypes/Portfolio/Overview/HoldingsTable/styles.tsx
+++ b/archetypes/Portfolio/Overview/HoldingsTable/styles.tsx
@@ -5,7 +5,7 @@ export const Container = styled.div`
     border-radius: 0.75rem;
     padding: 1.25rem;
     box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-    background: ${({ theme }) => theme.background};
+    background: ${({ theme }) => theme.background.primary};
 `;
 
 export const Title = styled.div`

--- a/archetypes/Portfolio/Overview/TradeOverviewBanner/styles.tsx
+++ b/archetypes/Portfolio/Overview/TradeOverviewBanner/styles.tsx
@@ -4,7 +4,7 @@ export const Banner = styled.div<{ showFullWidth?: boolean }>`
     padding: 1.25rem;
     border-radius: 0.75rem;
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-    background: ${({ theme }) => theme.background};
+    background: ${({ theme }) => theme.background.primary};
 `;
 
 export const Text = styled.div<{ isBold?: boolean; showOpacity?: boolean }>`
@@ -27,7 +27,7 @@ export const Card = styled.div`
     padding: 2.5rem 1.25rem 1.5rem;
     margin-top: 1.25rem;
     border-radius: 0.75rem;
-    background-color: ${({ theme }) => theme['background-secondary']};
+    background-color: ${({ theme }) => theme.background.secondary};
 `;
 
 export const CardTitle = styled.div`

--- a/components/General/Button/ExchangeButton.tsx
+++ b/components/General/Button/ExchangeButton.tsx
@@ -129,7 +129,7 @@ const Text = styled.p`
     line-height: 1.25rem;
     text-align: center;
     opacity: 0.7;
-    color: ${({ theme }) => theme.text};
+    color: ${({ theme }) => theme.fontColor.primary};
 `;
 
 const ButtonStyled = styled(Button)`

--- a/components/General/Checkbox/index.tsx
+++ b/components/General/Checkbox/index.tsx
@@ -46,7 +46,7 @@ const Input = styled.input`
 const Label = styled.label`
     margin-left: 30px;
     cursor: pointer;
-    color: ${({ theme }) => theme.text};
+    color: ${({ theme }) => theme.fontColor.primary};
     font-weight: 600;
 `;
 

--- a/components/General/Hide/index.tsx
+++ b/components/General/Hide/index.tsx
@@ -1,25 +1,24 @@
 import styled from 'styled-components';
-import { device } from '~/store/ThemeSlice/themes';
 
 type Display = HTMLDivElement['style']['display'];
 
 const MD = styled.div<{ display?: Display }>`
     ${({ display }) => (display ? `display: ${display};` : '')}
-    @media ${device.md} {
+    @media ${({ theme }) => theme.device.md} {
         display: none;
     }
 `;
 
 const LG = styled.div<{ display?: Display }>`
     ${({ display }) => (display ? `display: ${display};` : '')}
-    @media ${device.lg} {
+    @media ${({ theme }) => theme.device.lg} {
         display: none;
     }
 `;
 
 const XL = styled.div<{ display?: Display }>`
     ${({ display }) => (display ? `display: ${display};` : '')}
-    @media ${device.xl} {
+    @media ${({ theme }) => theme.device.xl} {
         display: none;
     }
 `;

--- a/components/General/Input/index.tsx
+++ b/components/General/Input/index.tsx
@@ -26,7 +26,7 @@ export const InputContainer = styled.div<{
     padding: 0.75rem;
     border-width: 1px;
     border-radius: 0.25rem;
-    background: ${({ theme }) => theme['button-bg']};
+    background: ${({ theme }) => theme.button.bg}
     outline: 1px solid transparent;
 
     ${({ theme, variation }) => {
@@ -37,11 +37,11 @@ export const InputContainer = styled.div<{
                 return warningStyles;
             default:
                 return `
-                    border-color: ${theme.border};
-                    color: ${theme.text};
+                    border-color: ${theme.border.primary};
+                    color: ${theme.fontColor.primary};
                     opacity: 0.8;
                     &:focus-within {
-                        outline-color: ${theme.primary};
+                        outline-color: ${theme.colors.primary};
                     }
 
             `;
@@ -57,5 +57,5 @@ export const InnerInputText = styled.div`
     bottom: 0;
     right: 1.25rem;
     height: 50%;
-    color: ${({ theme }) => theme.primary};
+    color: ${({ theme }) => theme.colors.primary};
 `;

--- a/components/General/Notification/Notification.tsx
+++ b/components/General/Notification/Notification.tsx
@@ -14,7 +14,7 @@ type NotificationProps = {
 
 const Title = styled.span`
     font-weight: 700;
-    color: ${({ theme }) => theme.text};
+    color: ${({ theme }) => theme.fontColor.primary};
     margin-left: 15px;
 `;
 

--- a/components/General/SearchInput/index.tsx
+++ b/components/General/SearchInput/index.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef } from 'react';
 import { SearchOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
-import { device } from '~/store/ThemeSlice/themes';
 
 interface SearchInputProps {
     className?: string;
@@ -57,7 +56,7 @@ export const InnerSearchInput = styled.input`
         outline: 1px solid ${({ theme }) => theme.colors.primary};
     }
 
-    @media (${device.sm}) {
+    @media ${({ theme }) => theme.device.sm} {
         // TODO create font-size css variables
         font-size: 0.875rem; /* 14px */
         line-height: 1.25rem; /* 20px */

--- a/components/General/SearchInput/index.tsx
+++ b/components/General/SearchInput/index.tsx
@@ -13,15 +13,15 @@ interface SearchInputProps {
 export const InputWrapper = styled.div`
     position: relative;
     width: 100%;
-    border: 1px ${({ theme }) => theme.border} solid;
+    border: 1px ${({ theme }) => theme.border.primary} solid;
     border-radius: 0.375rem; /* 6px */
-    background-color: ${({ theme }) => theme['button-bg']};
-    color: ${({ theme }) => theme['text-secondary']};
+    background-color: ${({ theme }) => theme.button.bg}
+    color: ${({ theme }) => theme.fontColor.secondary};
     font-weight: 500;
     box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 
     &:hover {
-        background-color: ${({ theme }) => theme['button-bg-hover']};
+        background-color: ${({ theme }) => theme.button.hover};
     }
 `;
 
@@ -50,11 +50,11 @@ export const InnerSearchInput = styled.input`
     // -1 px for the border top and bottom
     padding: calc(0.7rem - 1px) 1rem calc(0.7rem - 1px) 2.5rem;
 
-    border-color: ${({ theme }) => theme.border};
+    border-color: ${({ theme }) => theme.border.primary};
     border-radius: inherit;
 
     &:focus-visible {
-        outline: 1px solid ${({ theme }) => theme.primary};
+        outline: 1px solid ${({ theme }) => theme.colors.primary};
     }
 
     @media (${device.sm}) {

--- a/components/General/Show/index.tsx
+++ b/components/General/Show/index.tsx
@@ -1,25 +1,24 @@
 import styled from 'styled-components';
-import { device } from '~/store/ThemeSlice/themes';
 
 type Display = HTMLDivElement['style']['display'];
 
 const MD = styled.div<{ display: Display }>`
     display: none;
-    @media ${device.md} {
+    @media ${({ theme }) => theme.device.md} {
         display: ${({ display }) => display};
     }
 `;
 
 const LG = styled.div<{ display: Display }>`
     display: none;
-    @media ${device.lg} {
+    @media ${({ theme }) => theme.device.lg} {
         display: ${({ display }) => display};
     }
 `;
 
 const XL = styled.div<{ display: Display }>`
     display: none;
-    @media ${device.xl} {
+    @media ${({ theme }) => theme.device.xl} {
         display: ${({ display }) => display};
     }
 `;

--- a/components/General/TWTable/index.tsx
+++ b/components/General/TWTable/index.tsx
@@ -54,7 +54,7 @@ export const TableHeaderCell = styled.th.attrs((props) => ({
     line-height: 1rem; /* 16px */
     text-align: left;
     font-weight: 500;
-    color: ${({ theme }) => theme['text-secondary']};
+    color: ${({ theme }) => theme.fontColor.secondary};
     letter-spacing: 0.05em;
     text-transform: uppercase;
 
@@ -69,12 +69,12 @@ TableHeaderCell.defaultProps = {
 
 export const TableRow = styled.tr<{ lined?: boolean }>`
     &:nth-child(even) {
-        background: ${({ theme }) => theme.background};
+        background: ${({ theme }) => theme.background.primary};
     }
     &:nth-child(odd) {
         background: ${({ theme, lined }) => {
             if (!lined) {
-                return theme.background;
+                return theme.background.primary;
             }
             switch (theme.theme) {
                 case Theme.Dark:

--- a/components/General/index.tsx
+++ b/components/General/index.tsx
@@ -25,7 +25,7 @@ export const Section: React.FC<SProps> = styled(
     font-size: 14px;
     line-height: 18px;
     box-sizing: border-box;
-    color: ${({ theme }) => theme['text-secondary']};
+    color: ${({ theme }) => theme.fontColor.secondary};
     margin-bottom: 3px;
     &:not(.header) {
         margin-bottom: 1px;

--- a/components/Nav/Navbar/AccountDropdown/styles.tsx
+++ b/components/Nav/Navbar/AccountDropdown/styles.tsx
@@ -1,7 +1,6 @@
 import { CopyOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
 import { Logo } from '~/components/General';
-import { device } from '~/store/ThemeSlice/themes';
 
 export const ArbitrumLogo = styled(Logo)`
     display: inline;
@@ -68,7 +67,7 @@ export const Account = styled.div`
     white-space: nowrap;
     text-overflow: ellipsis;
 
-    @media ${device.md} {
+    @media ${({ theme }) => theme.device.md} {
         max-width: 100px;
     }
 `;

--- a/components/Nav/Navbar/AccountDropdown/styles.tsx
+++ b/components/Nav/Navbar/AccountDropdown/styles.tsx
@@ -16,7 +16,7 @@ export const ViewOnArbiscanOption = styled.a`
     display: flex;
     padding: 0.5rem 1rem;
     &:hover {
-        background: ${({ theme }) => theme['button-bg-hover']};
+        background: ${({ theme }) => theme.button.hover};
     }
 
     font-size: 0.875rem; /* 14px */

--- a/components/Nav/Navbar/NetworkDropdown.tsx
+++ b/components/Nav/Navbar/NetworkDropdown.tsx
@@ -34,7 +34,7 @@ const Option = styled.option`
     transition-duration: 150ms;
 
     &:hover {
-        background: ${({ theme }) => theme['button-bg-hover']};
+        background: ${({ theme }) => theme.button.hover};
     }
 `;
 

--- a/context/ThemeContext/index.tsx
+++ b/context/ThemeContext/index.tsx
@@ -20,7 +20,6 @@ export const StyledThemeProvider = ({ children }: { children: React.ReactNode })
             theme={{
                 ...baseTheme,
                 theme: theme,
-                isDark: theme === Theme.Dark || theme === Theme.Matrix,
             }}
         >
             {children}

--- a/context/ThemeContext/index.tsx
+++ b/context/ThemeContext/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { useStore } from '~/store/main';
 import { selectSetTheme, selectTheme } from '~/store/ThemeSlice';
-import { Theme, themes } from '~/store/ThemeSlice/themes';
+import { baseTheme, Theme } from '~/store/ThemeSlice/themes';
 
 export const StyledThemeProvider = ({ children }: { children: React.ReactNode }): JSX.Element => {
     const theme = useStore(selectTheme);
@@ -15,5 +15,15 @@ export const StyledThemeProvider = ({ children }: { children: React.ReactNode })
         }
     }, []);
 
-    return <ThemeProvider theme={themes[theme]}>{children}</ThemeProvider>;
+    return (
+        <ThemeProvider
+            theme={{
+                ...baseTheme,
+                theme: theme,
+                isDark: theme === Theme.Dark || theme === Theme.Matrix,
+            }}
+        >
+            {children}
+        </ThemeProvider>
+    );
 };

--- a/store/ThemeSlice/themes.ts
+++ b/store/ThemeSlice/themes.ts
@@ -4,111 +4,66 @@ export enum Theme {
     Matrix = 'matrix',
 }
 
-export const themes: Record<
-    Theme,
-    {
-        theme: Theme;
-        background: string;
-        'background-secondary': string;
-        'background-nav-secondary': string;
-        text: string;
-        'text-secondary': string;
-        border: string;
-        'border-secondary': string;
+export type BaseTheme = {
+    background: {
         primary: string;
-        'button-bg': string;
-        'button-bg-hover': string;
-        'is-dark': boolean;
-    }
-> = {
-    light: {
-        theme: Theme.Light,
-        background: '#fff',
-        /* gray-50 */
-        'background-secondary': '#f9fafb',
-        'background-nav-secondary': '#EEEEF6',
+        secondary: string;
+        tertiary: string;
+    };
 
-        /* cool-gray-900 */
-        text: '#111928',
+    fontColor: {
+        primary: string;
+        secondary: string;
+    };
+    fontFamily: {
+        body: string;
+        heading: string;
+    };
 
-        /* cool-gray-700 */
-        'text-secondary': '#374151',
+    border: {
+        primary: string;
+        secondary: string;
+    };
 
-        /* cool-gray-300*/
-        border: '#D1D5DB',
+    colors: {
+        primary: string;
+    };
 
-        /* cool-gray-200 */
-        'border-secondary': '#E5E7EB',
+    button: {
+        bg: string;
+        hover: string;
+    };
+};
 
-        /* tracer-800*/
-        primary: '#0000B0',
-
-        /* cool-gray-50 */
-        'button-bg': '#F9FAFB',
-
-        /* cool-gray-100 */
-        'button-bg-hover': '#F3F4F6',
-
-        'is-dark': false,
+export const baseTheme: BaseTheme = {
+    background: {
+        primary: 'var(--background)',
+        secondary: 'var(--background-secondary)',
+        tertiary: 'var(--background-nav-secondary)', // not used in styled-components
     },
-    dark: {
-        theme: Theme.Dark,
-        /* cool-gray-900 */
-        background: '#111928',
 
-        'background-secondary': '#1B2436',
-
-        /* cool-gray-900 */
-        'background-nav-secondary': '#111928',
-
-        /* gray-50 */
-        text: '#FAFAFA',
-
-        /* cool-gray-200 */
-        'text-secondary': '#E5E7EB',
-
-        /* cool-gray-500*/
-        border: '#6B7280',
-
-        /* cool-gray-700 */
-        'border-secondary': '#374151',
-
-        /* tracer-100*/
-        primary: '#DEDEFF',
-
-        /* cool-gray-800 */
-        'button-bg': '#1F2A37',
-
-        /* cool-gray-700 */
-        'button-bg-hover': '#374151',
-
-        'is-dark': true,
+    fontColor: {
+        primary: 'var(--text)',
+        secondary: 'var(--text-secondary)',
     },
-    matrix: {
-        theme: Theme.Matrix,
-        /* cool-gray-900 */
-        background: '#020204',
 
-        'background-secondary': '#003b00',
+    colors: {
+        primary: 'var(--primary)',
+    },
 
-        'background-nav-secondary': '#020204',
+    border: {
+        primary: 'var(--border)',
+        secondary: 'var(--border-secondary)',
+    },
 
-        text: '#22b455',
+    button: {
+        bg: 'var(--button-bg)',
+        hover: 'var(--button-bg-hover)',
+    },
 
-        'text-secondary': '#80ce87',
-
-        border: '#008f11',
-
-        //TODO get correct color for matrix
-        'border-secondary': '#E5E7EB',
-
-        primary: '#00ff41',
-
-        'button-bg': '#003b00',
-
-        'button-bg-hover': '#020204',
-
-        'is-dark': false,
+    fontFamily: {
+        body: "'Inter', sans-serif",
+        heading: "'Source Sans Pro', sans-serif",
     },
 };
 

--- a/store/ThemeSlice/themes.ts
+++ b/store/ThemeSlice/themes.ts
@@ -4,20 +4,19 @@ export enum Theme {
     Matrix = 'matrix',
 }
 
+const size = {
+    sm: '640px',
+    md: '768px',
+    lg: '1024px',
+    xl: '1280px',
+    '2xl': '1536px',
+};
+
 export type BaseTheme = {
     background: {
         primary: string;
         secondary: string;
         tertiary: string;
-    };
-
-    fontColor: {
-        primary: string;
-        secondary: string;
-    };
-    fontFamily: {
-        body: string;
-        heading: string;
     };
 
     border: {
@@ -33,6 +32,33 @@ export type BaseTheme = {
         bg: string;
         hover: string;
     };
+
+    fontColor: {
+        primary: string;
+        secondary: string;
+    };
+    fontFamily: {
+        body: string;
+        heading: string;
+    };
+    fontSize: {
+        xxxs: string;
+        xxs: string;
+        xs: string;
+        sm: string;
+        md: string;
+        lg: string;
+        xl: string;
+        xxl: string;
+        xxxl: string;
+    };
+    device: {
+        sm: string;
+        md: string;
+        lg: string;
+        xl: string;
+        '2xl': string;
+    };
 };
 
 export const baseTheme: BaseTheme = {
@@ -40,11 +66,6 @@ export const baseTheme: BaseTheme = {
         primary: 'var(--background)',
         secondary: 'var(--background-secondary)',
         tertiary: 'var(--background-nav-secondary)', // not used in styled-components
-    },
-
-    fontColor: {
-        primary: 'var(--text)',
-        secondary: 'var(--text-secondary)',
     },
 
     colors: {
@@ -61,24 +82,33 @@ export const baseTheme: BaseTheme = {
         hover: 'var(--button-bg-hover)',
     },
 
+    fontColor: {
+        primary: 'var(--text)',
+        secondary: 'var(--text-secondary)',
+    },
+
     fontFamily: {
         body: "'Inter', sans-serif",
         heading: "'Source Sans Pro', sans-serif",
     },
-};
 
-const size = {
-    sm: '640px',
-    md: '768px',
-    lg: '1024px',
-    xl: '1280px',
-    '2xl': '1536px',
-};
+    fontSize: {
+        xxxs: '0.625rem', // 10px
+        xxs: '0.75rem', // 12px
+        xs: '0.875rem', // 14px
+        sm: '0.938rem', // 15px
+        md: '1rem', // 16px
+        lg: '1.125rem', // 18px
+        xl: '1.25rem', // 20px
+        xxl: '1.5rem', // 24px
+        xxxl: '2rem', // 32px
+    },
 
-export const device = {
-    sm: `(min-width: ${size.sm})`,
-    md: `(min-width: ${size.md})`,
-    lg: `(min-width: ${size.lg})`,
-    xl: `(min-width: ${size.xl})`,
-    '2xl': `(min-width: ${size['2xl']})`,
+    device: {
+        sm: `(min-width: ${size.sm})`,
+        md: `(min-width: ${size.md})`,
+        lg: `(min-width: ${size.lg})`,
+        xl: `(min-width: ${size.xl})`,
+        '2xl': `(min-width: ${size['2xl']})`,
+    },
 };

--- a/styles/index.css
+++ b/styles/index.css
@@ -178,7 +178,7 @@ html {
 
     /* cool-gray-700 */
     --text: #374151;
-    text-secondary: #374151;
+    --text-secondary: #374151;
 
     /* cool-gray-300*/
     --border: #d1d5db;

--- a/styles/index.css
+++ b/styles/index.css
@@ -160,6 +160,13 @@ body {
     font-size: 16px;
 }
 
+@media (max-height: 800px) and (min-width: 1024px) {
+    html {
+        font-size: 12px;
+    }
+}
+
+
 /* Colour themes */
 html {
     --background: #fff;
@@ -171,9 +178,12 @@ html {
 
     /* cool-gray-700 */
     --text: #374151;
+    text-secondary: #374151;
 
     /* cool-gray-300*/
     --border: #d1d5db;
+
+    --border-secondary: #E5E7EB;
 
     /* tracer-800*/
     --primary: #0000b0;
@@ -183,12 +193,6 @@ html {
 
     /* cool-gray-100 */
     --button-bg-hover: #f3f4f6;
-}
-
-@media (max-height: 800px) and (min-width: 1024px) {
-    html {
-        font-size: 12px;
-    }
 }
 
 html.theme-dark {
@@ -208,6 +212,7 @@ html.theme-dark {
 
     /* cool-gray-500*/
     --border: #6b7280;
+    --border-secondary: #374151;
 
     /* tracer-100*/
     --primary: #dedeff;
@@ -228,10 +233,10 @@ html.theme-matrix {
     --background-nav-secondary: #020204;
 
     --text: #22b455;
-
     --text-secondary: #80ce87;
 
     --border: #008f11;
+    --border-secondary: #008f11;
 
     --primary: #00ff41;
 


### PR DESCRIPTION
I think the styled-components theme provider isnt the best way to handle switching between themes, this pr collapses it a little such that it still uses the nice styled-components api and we can continue to do more complex theme based styles, but keeps the base colors using css variables such that there is no flash of themes on initial load.

- use css variables instead of js variables for themes
- add fontSizes to theme