### PR TITLE
re-enable long mint from escrow balance

### DIFF
--- a/archetypes/Exchange/Inputs/index.tsx
+++ b/archetypes/Exchange/Inputs/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
 import { CommitActionEnum, BalanceTypeEnum, SideEnum } from '@tracer-protocol/pools-js';
 import TWButtonGroup from '~/components/General/TWButtonGroup';
-import { TooltipKeys } from '~/components/Tooltips/TooltipSelector';
 import { SwapState, useBigNumber, SwapAction } from '~/context/SwapContext';
 import usePoolsNextBalances from '~/hooks/usePoolsNextBalances';
 import usePoolTokens from '~/hooks/usePoolTokens';
@@ -10,7 +9,7 @@ import { PoolInfo } from '~/types/pools';
 import { toApproxCurrency } from '~/utils/converters';
 import AmountInput from './AmountInput';
 import * as Styles from './styles';
-import { InvalidAmount } from './types';
+import { InvalidAmount, WALLET_OPTIONS } from './types';
 import TokenSelect from '../TokenSelect';
 
 /* HELPER FUNCTIONS */
@@ -78,23 +77,6 @@ export default (({ pool, userBalances, swapState, swapDispatch }) => {
     );
 
     const tokenPrice = useMemo(() => (isLong ? pool.getNextLongTokenPrice() : pool.getNextShortTokenPrice()), [isLong]);
-
-    const TEMP_WALLET_OPTIONS = [
-        {
-            key: BalanceTypeEnum.wallet,
-            text: 'Wallet',
-        },
-        {
-            key: BalanceTypeEnum.escrow,
-            text: 'Escrow',
-            disabled:
-                isLong && commitAction === CommitActionEnum.mint
-                    ? {
-                          optionKey: TooltipKeys.EscrowLongUnavailable,
-                      }
-                    : undefined,
-        },
-    ];
 
     useEffect(() => {
         if (pool) {
@@ -168,7 +150,7 @@ export default (({ pool, userBalances, swapState, swapDispatch }) => {
                                 swapDispatch({ type: 'setBalanceType', value: val });
                             }
                         }}
-                        options={TEMP_WALLET_OPTIONS}
+                        options={WALLET_OPTIONS}
                     />
                 </Styles.Wrapper>
             </Styles.Container>

--- a/components/Tooltips/TooltipSelector/index.tsx
+++ b/components/Tooltips/TooltipSelector/index.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { StyledTooltip, LockTip, ComingSoonTip, PowerLeverageTip, EscrowLongUnavailableTooltip } from '../';
+import { StyledTooltip, LockTip, ComingSoonTip, PowerLeverageTip } from '../';
 
 export enum TooltipKeys {
     ComingSoon = 'coming-soon',
     Lock = 'Lock',
     PowerLeverage = 'power-leverage',
-    EscrowLongUnavailable = 'escrow-unavailable',
 }
 
 export type TooltipSelectorProps = {
@@ -23,9 +22,6 @@ const TooltipSelector: React.FC<{ tooltip: TooltipSelectorProps }> = ({ tooltip,
 
         case TooltipKeys.PowerLeverage:
             return <PowerLeverageTip>{children}</PowerLeverageTip>;
-
-        case TooltipKeys.EscrowLongUnavailable:
-            return <EscrowLongUnavailableTooltip>{children}</EscrowLongUnavailableTooltip>;
 
         default:
             return <StyledTooltip title={tooltip.content}>{children}</StyledTooltip>;

--- a/components/Tooltips/index.tsx
+++ b/components/Tooltips/index.tsx
@@ -78,10 +78,3 @@ export const GasPriceTooltip: React.FC<{
     );
     return <StyledTooltip title={Content}>{children}</StyledTooltip>;
 };
-
-export const EscrowLongUnavailableTooltip: React.FC = ({ children }) => {
-    const Content = (
-        <>Long mint from escrow unavailable. Please use tokens from wallet, or claim from escrow before minting</>
-    );
-    return <StyledTooltip title={Content}>{children}</StyledTooltip>;
-};


### PR DESCRIPTION
# Motivation
We temporarily disabled long minting from escrow for the trading comp due to a contract bug. Contracts have been redeployed with a fix so this no longer applies

# Changes
re-enables long mint from escrow (essentially reverts changes from https://github.com/tracer-protocol/pools-client/pull/580)