### PR TITLE
Set token price to three decimal places

### DIFF
--- a/archetypes/Exchange/Inputs/AmountInput.tsx
+++ b/archetypes/Exchange/Inputs/AmountInput.tsx
@@ -19,8 +19,8 @@ const Available: React.FC<{
             {`Available: `}
             {isPoolToken ? (
                 <>
-                    {`${balance.toFixed(2)} `}
-                    {amountBN.gt(0) ? <span className="opacity-80">{`>>> ${balanceAfter.toFixed(2)}`}</span> : null}
+                    {`${balance.toFixed(3)} `}
+                    {amountBN.gt(0) ? <span className="opacity-80">{`>>> ${balanceAfter.toFixed(3)}`}</span> : null}
                 </>
             ) : (
                 <>

--- a/archetypes/Exchange/Inputs/index.tsx
+++ b/archetypes/Exchange/Inputs/index.tsx
@@ -109,7 +109,7 @@ export default (({ pool, userBalances, swapState, swapDispatch }) => {
                     }}
                 />
                 <Styles.Subtext showContent={!!pool.address}>
-                    Expected Price: {toApproxCurrency(tokenPrice)}
+                    Expected Price: {toApproxCurrency(tokenPrice, 3)}
                 </Styles.Subtext>
             </Styles.Wrapper>
             <Styles.Container>

--- a/archetypes/Exchange/Summary/MintSummary.tsx
+++ b/archetypes/Exchange/Summary/MintSummary.tsx
@@ -23,6 +23,7 @@ const MintSummary: React.FC<MintSummaryProps> = ({ amount, nextTokenPrice, token
                 expectedTokensMinted={expectedAmount.toNumber()}
                 nextTokenPrice={nextTokenPrice}
                 tokenSymbol={token.symbol}
+                settlementTokenSymbol={pool.settlementTokenSymbol}
             />
             <ExpectedExposure
                 label={'Expected equivalent exposure'}

--- a/archetypes/Exchange/Summary/Sections.tsx
+++ b/archetypes/Exchange/Summary/Sections.tsx
@@ -10,9 +10,12 @@ import { calcNumTokens } from './utils';
 
 export const ExpectedTokenPrice: React.FC<{
     tokenPrice: BigNumber;
-}> = ({ tokenPrice }) => (
+    settlementTokenSymbol: string;
+}> = ({ tokenPrice, settlementTokenSymbol }) => (
     <div>
-        <Styles.Transparent>{` at ${toApproxCurrency(tokenPrice ?? 1, 2)} USD/token`}</Styles.Transparent>
+        <Styles.Transparent>
+            {` at ${toApproxCurrency(tokenPrice ?? 1, 3)} ${settlementTokenSymbol}/token`}
+        </Styles.Transparent>
     </div>
 );
 
@@ -51,6 +54,7 @@ export const ExpectedTokensMinted: React.FC<
         expectedTokensMinted: number;
         nextTokenPrice: BigNumber;
         tokenSymbol: string;
+        settlementTokenSymbol: string;
     } & BaseSection
 > = ({ expectedTokensMinted, nextTokenPrice, tokenSymbol, showTransactionDetails }) => (
     <>
@@ -67,7 +71,7 @@ export const ExpectedTokensMinted: React.FC<
                     </Styles.Transparent>
                 </Section>
                 <Section label="Expected price" showSectionDetails>
-                    <ExpectedTokenPrice tokenPrice={nextTokenPrice} />
+                    <ExpectedTokenPrice tokenPrice={nextTokenPrice} settlementTokenSymbol={settlementTokenSymbol} />
                 </Section>
             </Styles.SectionDetails>
         )}
@@ -94,7 +98,7 @@ export const ExpectedTokenValue: React.FC<
                     <Styles.Transparent>{`${amount}`} tokens</Styles.Transparent>
                 </Section>
                 <Section label="Expected price" showSectionDetails>
-                    <ExpectedTokenPrice tokenPrice={nextTokenPrice} />
+                    <ExpectedTokenPrice tokenPrice={nextTokenPrice} settlementTokenSymbol={settlementTokenSymbol} />
                 </Section>
             </Styles.SectionDetails>
         )}
@@ -211,7 +215,10 @@ export const ExpectedFlipAmounts: React.FC<
                         </Styles.Transparent>
                     </Section>
                     <Section label={`Expected ${isLong ? 'short' : 'long'} token price`} showSectionDetails>
-                        <ExpectedTokenPrice tokenPrice={nextFlipTokenPrice} />
+                        <ExpectedTokenPrice
+                            tokenPrice={nextFlipTokenPrice}
+                            settlementTokenSymbol={settlementTokenSymbol}
+                        />
                     </Section>
                     <Section label={`Expected amount of ${isLong ? 'short' : 'long'} tokens`} showSectionDetails>
                         <Styles.Transparent>

--- a/archetypes/Exchange/Summary/Sections.tsx
+++ b/archetypes/Exchange/Summary/Sections.tsx
@@ -56,7 +56,7 @@ export const ExpectedTokensMinted: React.FC<
         tokenSymbol: string;
         settlementTokenSymbol: string;
     } & BaseSection
-> = ({ expectedTokensMinted, nextTokenPrice, tokenSymbol, showTransactionDetails }) => (
+> = ({ expectedTokensMinted, nextTokenPrice, tokenSymbol, showTransactionDetails, settlementTokenSymbol }) => (
     <>
         <Section label="Expected tokens minted" className="header">
             <Styles.SumText>

--- a/archetypes/Exchange/Summary/index.tsx
+++ b/archetypes/Exchange/Summary/index.tsx
@@ -35,6 +35,7 @@ export default (({ pool, showBreakdown, amount, isLong, receiveIn, commitAction,
                                 name: pool.name,
                                 oraclePrice: pool.oraclePrice,
                                 leverage: pool.leverage,
+                                settlementTokenSymbol: pool.settlementToken.symbol,
                             }}
                             gasFee={gasFee}
                             isLong={isLong}

--- a/archetypes/Exchange/Summary/types.ts
+++ b/archetypes/Exchange/Summary/types.ts
@@ -31,6 +31,7 @@ export type MintSummaryProps = {
         name: string;
         oraclePrice: BigNumber;
         leverage: number;
+        settlementTokenSymbol: string;
     };
 } & SharedProps;
 

--- a/archetypes/Exchange/TokenSelect/TokenSelect.tsx
+++ b/archetypes/Exchange/TokenSelect/TokenSelect.tsx
@@ -84,7 +84,7 @@ const TokenSelect: React.FC<{
                                     <Styles.TokenSelectCell hasBalance={token.escrowBalance.toNumber() > 0}>
                                         {token.escrowBalance.toNumber() > 0 ? (
                                             <>
-                                                {token.escrowBalance?.toFixed(2)}
+                                                {token.escrowBalance?.toFixed(3)}
                                                 <span>Tokens</span>
                                             </>
                                         ) : (
@@ -94,7 +94,7 @@ const TokenSelect: React.FC<{
                                     <Styles.TokenSelectCell hasBalance={token.balance.toNumber() > 0}>
                                         {token.balance.toNumber() > 0 ? (
                                             <>
-                                                {token.balance.toNumber().toFixed(2)}
+                                                {token.balance.toNumber().toFixed(3)}
                                                 <span>Tokens</span>
                                             </>
                                         ) : (


### PR DESCRIPTION
Set token price decimals to 3 as per https://tracerfinance.atlassian.net/browse/PML-71
Sorry forgot to name branch after ticket.

- set token price to 3 decimal places
- use settlementTokenSymbol instead of USD