### PR TITLE
Remove fixed search height

### DIFF
--- a/archetypes/Portfolio/OverviewTable/styles.tsx
+++ b/archetypes/Portfolio/OverviewTable/styles.tsx
@@ -74,7 +74,6 @@ export const Actions = styled.div`
 
 export const SearchInput = styled(UnstyledSearchInput)`
     min-width: 325px;
-    height: 38px;
     input {
         padding: calc(0.5rem - 1px) 1rem calc(0.5rem - 1px) 2.5rem;
     }


### PR DESCRIPTION
https://tracerfinance.atlassian.net/browse/PML-111
Remove fixed search height on the portfolio page. Effects smaller height screens when base font size gets reduced.

To test reduce height of screen to 750px
