### PR TITLE
Convert page entries to 6

### DIFF
--- a/archetypes/Portfolio/HistoricCommits/index.tsx
+++ b/archetypes/Portfolio/HistoricCommits/index.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { CommitEnum } from '@tracer-protocol/pools-js';
 import Pagination, { PageNumber } from '~/components/General/Pagination';
-import { useHistoricCommits } from '~/hooks/useHistoricCommits';
-import { PAGE_ENTRIES } from '~/hooks/usePagination';
+import { useHistoricCommits, PAGE_ENTRIES } from '~/hooks/useHistoricCommits';
 import { TradeHistory } from '~/types/commits';
 import HistoricCommitsTable from './HistoricCommitsTable';
 import * as Styles from './styles';

--- a/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensRows.tsx
+++ b/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensRows.tsx
@@ -30,14 +30,14 @@ export const ClaimablePoolTokenRow: React.FC<ClaimablePoolTokenRowProps & { sett
             </OverviewTableRowCell>
             <OverviewTableRowCell>
                 <TokensNotional
-                    amount={currentTokenPrice.times(balance)}
+                    amount={balance}
                     price={currentTokenPrice}
                     settlementTokenSymbol={settlementTokenSymbol}
                 />
             </OverviewTableRowCell>
             <OverviewTableRowCell>
                 <TokensNotional
-                    amount={currentTokenPrice.times(balance)}
+                    amount={balance}
                     price={currentTokenPrice}
                     settlementTokenSymbol={settlementTokenSymbol}
                 />

--- a/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensRows.tsx
+++ b/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensRows.tsx
@@ -36,11 +36,7 @@ export const ClaimablePoolTokenRow: React.FC<ClaimablePoolTokenRowProps & { sett
                 />
             </OverviewTableRowCell>
             <OverviewTableRowCell>
-                <TokensNotional
-                    amount={balance}
-                    price={currentTokenPrice}
-                    settlementTokenSymbol={settlementTokenSymbol}
-                />
+                <TokensNotional amount={balance} price={entryPrice} settlementTokenSymbol={settlementTokenSymbol} />
             </OverviewTableRowCell>
             <OverviewTableRowCell>
                 <div>

--- a/hooks/useHistoricCommits/index.tsx
+++ b/hooks/useHistoricCommits/index.tsx
@@ -10,7 +10,7 @@ import { LoadingRows } from '~/types/hooks';
 import { V2_SUPPORTED_NETWORKS } from '~/types/networks';
 import { fetchCommitHistory } from '~/utils/tracerAPI';
 
-const PAGE_ENTRIES = 6;
+export const PAGE_ENTRIES = 6;
 
 export const useHistoricCommits = (
     typeFilter: CommitTypeFilter,

--- a/hooks/usePagination/index.tsx
+++ b/hooks/usePagination/index.tsx
@@ -1,26 +1,32 @@
 import { Dispatch, SetStateAction, useMemo, useEffect, useState } from 'react';
 
-// TODO could make this a param for configurable number of page entries
-export const PAGE_ENTRIES = 10;
+export const DEFAULT_PAGE_ENTRIES = 10;
+
+type PaginationControl = {
+    setPage: Dispatch<SetStateAction<number>>;
+    paginatedArray: any[];
+    numPages: number;
+    page: number;
+};
 
 // hook to assist with paginating an array
-export default ((arr: any[]) => {
+export const usePagination = (arr: any[], pageEntries: number = DEFAULT_PAGE_ENTRIES): PaginationControl => {
     const [page, setPage] = useState<number>(1);
     const [numPages, setNumPages] = useState<number>(1);
     const [paginatedArray, setPaginatedArray] = useState<any[]>([]);
 
     useMemo(() => {
-        const start = (page - 1) * PAGE_ENTRIES;
-        const end = start + PAGE_ENTRIES;
+        const start = (page - 1) * pageEntries;
+        const end = start + pageEntries;
         setPaginatedArray(arr.slice(start, end));
     }, [page]);
 
     useEffect(() => {
         if (arr.length) {
-            const start = (page - 1) * PAGE_ENTRIES;
-            const end = start + PAGE_ENTRIES;
+            const start = (page - 1) * pageEntries;
+            const end = start + pageEntries;
             setPaginatedArray(arr.slice(start, end));
-            setNumPages(Math.ceil(arr.length / PAGE_ENTRIES));
+            setNumPages(Math.ceil(arr.length / pageEntries));
         } else {
             setPage(1);
             setNumPages(1);
@@ -33,9 +39,6 @@ export default ((arr: any[]) => {
         setPage,
         numPages,
     };
-}) as (arr: any[]) => {
-    setPage: Dispatch<SetStateAction<number>>;
-    paginatedArray: any[];
-    numPages: number;
-    page: number;
 };
+
+export default usePagination;


### PR DESCRIPTION
- Convert historic commits table to 6 page entries.
- Fix notional value display of unclaimed tokens

https://tracerfinance.atlassian.net/browse/PML-116

Note: doesnt actually use the usePagination hook any more but thought Id update anyway