### PR TITLE
always format trade history fees as 18 decimal places

### DIFF
--- a/utils/tracerAPI/api.ts
+++ b/utils/tracerAPI/api.ts
@@ -113,7 +113,7 @@ export const fetchCommitHistory: (params: {
                     dateString,
                     timeString,
                     commitType,
-                    fee: formatBN(new BigNumber(row.fee), decimals),
+                    fee: formatBN(new BigNumber(row.fee), 18), // fees is always in WAD (18 decimal places)
                     txnHashIn: row.transactionHashIn,
                     txnHashOut: row.transactionHashOut,
                     settlementToken: {


### PR DESCRIPTION
fee from trade history api is always in WAD format so always format with 18 decimal places instead of `settlementToken` decimals