### PR TITLE
Convert to general token names

### DIFF
--- a/archetypes/Portfolio/Market.tsx
+++ b/archetypes/Portfolio/Market.tsx
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 import styled from 'styled-components';
 import { Logo, LogoTicker, tokenSymbolToLogoTicker } from '~/components/General';
 import { toApproxCurrency } from '~/utils/converters';
-import { getMarketInfoFromSymbol, marketSymbolToAssetName } from '~/utils/poolNames';
+import { getMarketInfoFromSymbol, getSimplifiedTokenName, marketSymbolToAssetName } from '~/utils/poolNames';
 import { InnerCellSubText } from './styles';
 
 const MarketContainer = styled.div`
@@ -72,7 +72,11 @@ export const TokenPrice = ({
     tokenOutSymbol: string;
     tokenInSymbol: string;
     price: BigNumber;
-}): JSX.Element => <div>{`${price.toFixed(2)} ${tokenOutSymbol}/${tokenInSymbol}`}</div>;
+}): JSX.Element => {
+    const simplifiedIn = getSimplifiedTokenName(tokenInSymbol);
+    const simplifiedOut = getSimplifiedTokenName(tokenOutSymbol);
+    return <div>{`${price.toFixed(2)} ${simplifiedIn}/${simplifiedOut}`}</div>;
+};
 
 export const Amount = ({ tokenSymbol, amount }: { tokenSymbol: string; amount: BigNumber }): JSX.Element => (
     <MarketContainer>

--- a/utils/poolNames.ts
+++ b/utils/poolNames.ts
@@ -75,6 +75,21 @@ export const getMarketInfoFromSymbol = (
     };
 };
 
+export const getSimplifiedTokenName = (tokenSymbol: string): string => {
+    // not 100% accurate but is unlikely other tokenSymbols have this form
+    const tokenSymbolRegex = /([0-9]*)(?:|L|S)\-([A-Z]*)/g;
+    const symbol = tokenSymbol.match(tokenSymbolRegex)?.[0];
+    if (!symbol) {
+        return tokenSymbol;
+    } else {
+        const side = tokenSymbol.split('-')[0].slice(-1);
+        if (!side) {
+            return tokenSymbol;
+        }
+        return side === 'L' ? 'Long Token' : 'Short Token';
+    }
+};
+
 /**
  * Converts a token symbol to a shortened version < 11 characters
  * @param tokenSymbol pool generated token symbol


### PR DESCRIPTION
Set token names to general Short/Long tokens. Skips if the token symbol is not recognized as a pool token symbol which has the form {LEVERAGE}{L/S}-{POOL_NAME}

https://tracerfinance.atlassian.net/browse/PML-126