### PR TITLE
Reduce search bar sizes

### DIFF
--- a/archetypes/Stake/StakeGeneric/index.tsx
+++ b/archetypes/Stake/StakeGeneric/index.tsx
@@ -11,8 +11,8 @@ import { selectAccount, selectProvider } from '~/store/Web3Slice';
 import { SideFilterEnum, LeverageFilterEnum, MarketFilterEnum, StakeSortByEnum } from '~/types/filters';
 import { Farm } from '~/types/staking';
 
-import { escapeRegExp } from '~/utils/helpers';
 import { generalMarketFilter } from '~/utils/filters';
+import { escapeRegExp } from '~/utils/helpers';
 import FarmsTable from '../FarmsTable';
 import FilterBar from '../FilterSelects';
 import StakeModal from '../StakeModal';

--- a/components/BaseFilters/index.tsx
+++ b/components/BaseFilters/index.tsx
@@ -10,6 +10,10 @@ import { CollateralFilter } from './CollateralFilter';
 import { LeverageFilter } from './LeverageFilter';
 import { MarketFilter } from './MarketFilter';
 
+// Magic number padding. Used in FilterPopup and SearchInput
+// to make them the same size
+const buttonPadding = '9.5px';
+
 export const Container = styled(UnstyledContainer)`
     display: flex;
     margin-right: 0;
@@ -39,7 +43,7 @@ export const FilterPopup = styled(TWPopup)`
         font-weight: 400 !important;
         color: rgb(156 163 175);
         display: inline-flex;
-        padding: 0.67rem 1rem;
+        padding: ${buttonPadding} 1rem;
         background-color: ${({ theme }) => theme.button.bg};
         white-space: nowrap;
         display: inline-flex;
@@ -93,8 +97,7 @@ export const Wrapper = styled.div`
 export const SearchInput = styled(UnstyledSearchInput)`
     width: 100%;
     input {
-        height: calc(24px + 0.67rem * 2);
-        padding: 0.67rem 1rem;
+        height: calc(24px + ${buttonPadding} * 2);
         font-size: 16px;
         padding: 0 1rem 0 2.5rem;
     }


### PR DESCRIPTION
Reduce search bar sizes to match designs, pretty hard to tell in these screenshots but just reduced 2.5px in height, lol
https://www.figma.com/file/gA9jQ5B6ZwWjGKBhGUFbKo/2.0-3.0-Pools?node-id=1911%3A164247

<img width="1312" alt="Screen Shot 2022-05-18 at 8 30 09 am" src="https://user-images.githubusercontent.com/29347276/168922777-0e93bd9a-923b-44e8-90c8-5bb025073d97.png">
<img width="1312" alt="Screen Shot 2022-05-18 at 8 30 27 am" src="https://user-images.githubusercontent.com/29347276/168922780-7735f9a2-598a-4b27-b08e-41af202fd15d.png">
