### PR TITLE
V2/fit pools without scroll

### DIFF
--- a/archetypes/Pools/PoolsTable/index.tsx
+++ b/archetypes/Pools/PoolsTable/index.tsx
@@ -157,7 +157,7 @@ export const PoolsTable = ({
                     <tr className="h-5" />
                     <tr>
                         {/* Pools  Cols */}
-                        <TableHeaderCell className="w-1/12">Leverage/Collateral</TableHeaderCell>
+                        <TableHeaderCell className="w-1/12 2xl:whitespace-nowrap">Leverage / Collateral</TableHeaderCell>
                         <TableHeaderCell className="w-1/12 whitespace-nowrap">
                             {/* TODO: do something else when we have a pool using a non-USDC underlying feed */}
                             {'INDEX PRICE (USD)'}

--- a/archetypes/Pools/index.tsx
+++ b/archetypes/Pools/index.tsx
@@ -132,10 +132,10 @@ export const Browse: React.FC = () => {
                             </NetworkHintContainer>
                         </PageTable.Heading>
                         <PageTable.SubHeading>
-                            The most liquid, unique pools with mitigated volatility decay. Secured by Chainlink Oracles,
-                            via Tracer’s SMA Wrapper.{' '}
-                            <PageTable.Link href="https://pools.docs.tracer.finance/perpetual-pools/readme">
-                                Learn More
+                            Unlocking Perpetual Pools v2 - take part in the Tracer Voyage to experience the true power
+                            of DeFi.{' '}
+                            <PageTable.Link href="https://tracer.finance/radar/the-tracer-voyage/">
+                                Learn More.
                             </PageTable.Link>
                         </PageTable.SubHeading>
                     </div>

--- a/archetypes/Pools/styles.tsx
+++ b/archetypes/Pools/styles.tsx
@@ -18,7 +18,7 @@ export const DataRow = styled.div`
         border-radius: 1rem;
     }
     @media ${({ theme }) => theme.device.md} {
-        padding: 2rem;
+        padding: 2rem 1rem;
         border-radius: 1.5rem;
     }
 `;


### PR DESCRIPTION
Went a bit off script here but was annoying me how close it was. This fits it into my screen breakpoint.
Fit pools table on one screen without scroll