### PR TITLE
include the pending mint spend in portfolio delta

### DIFF
--- a/hooks/usePortfolioOverview/index.tsx
+++ b/hooks/usePortfolioOverview/index.tsx
@@ -38,13 +38,8 @@ export const usePortfolioOverview = (): PortfolioOverview => {
 
             poolValues.forEach((pool) => {
                 const { poolInstance, userBalances } = pool;
-                const {
-                    totalLongBurnReceived,
-                    totalShortBurnReceived,
-
-                    totalLongMintSpend,
-                    totalShortMintSpend,
-                } = userBalances.tradeStats;
+                const { totalLongBurnReceived, totalShortBurnReceived, totalLongMintSpend, totalShortMintSpend } =
+                    userBalances.tradeStats;
 
                 const pendingAmounts =
                     poolPendingCommitAmounts?.[pool.poolInstance.address.toLowerCase()]?.[account] ??
@@ -63,13 +58,17 @@ export const usePortfolioOverview = (): PortfolioOverview => {
                     .plus(calcNotionalValue(longTokenPrice, userBalances.aggregateBalances.longTokens))
                     // TODO handle non stable coin settlementTokens
                     .plus(userBalances.aggregateBalances.settlementTokens)
-                    .plus(pendingAmounts.longMint)
-                    .plus(pendingAmounts.shortMint)
+                    .plus(pendingAmounts.longMint.div(nextLongTokenPrice))
+                    .plus(pendingAmounts.shortMint.div(nextShortTokenPrice))
                     // not accurate but not sure how much it matters
                     .plus(calcNotionalValue(nextLongTokenPrice, pendingAmounts.longBurn))
                     .plus(calcNotionalValue(nextShortTokenPrice, pendingAmounts.shortBurn));
 
-                totalSettlementSpend = totalSettlementSpend.plus(totalLongMintSpend).plus(totalShortMintSpend);
+                totalSettlementSpend = totalSettlementSpend
+                    .plus(totalLongMintSpend)
+                    .plus(totalShortMintSpend)
+                    .plus(pendingAmounts.longMint)
+                    .plus(pendingAmounts.longMint);
 
                 realisedProfit = realisedProfit.plus(totalShortBurnReceived).plus(totalLongBurnReceived);
             });


### PR DESCRIPTION
I noticed that the portfolio page did not account for the money spent on pending mints and said I was up the full amount that I spent.

before:
![image](https://user-images.githubusercontent.com/14157626/169273779-0176b696-128f-4ada-a927-d05722cd2514.png)

after:
![image](https://user-images.githubusercontent.com/14157626/169273844-e9bc01d1-70e1-47b4-994e-34823b5feb2b.png)

