### PR TITLE
V2/persist route on toggle

### DIFF
--- a/archetypes/Pools/PoolsTable/index.tsx
+++ b/archetypes/Pools/PoolsTable/index.tsx
@@ -157,7 +157,9 @@ export const PoolsTable = ({
                     <tr className="h-5" />
                     <tr>
                         {/* Pools  Cols */}
-                        <TableHeaderCell className="w-1/12 2xl:whitespace-nowrap">Leverage / Collateral</TableHeaderCell>
+                        <TableHeaderCell className="w-1/12 2xl:whitespace-nowrap">
+                            Leverage / Collateral
+                        </TableHeaderCell>
                         <TableHeaderCell className="w-1/12 whitespace-nowrap">
                             {/* TODO: do something else when we have a pool using a non-USDC underlying feed */}
                             {'INDEX PRICE (USD)'}

--- a/components/Nav/Navbar/VersionToggle.tsx
+++ b/components/Nav/Navbar/VersionToggle.tsx
@@ -22,9 +22,7 @@ export const VersionToggle = ({ hideOnDesktop }: VersionToggleProps): JSX.Elemen
     return (
         <StyledVersionToggle hideOnDesktop={hideOnDesktop}>
             <V1 href={getRoute()}>V1</V1>
-            <V2>
-                V2 <New>BETA</New>
-            </V2>
+            <V2>V2</V2>
         </StyledVersionToggle>
     );
 };
@@ -63,27 +61,11 @@ const V1 = styled.a`
 `;
 
 const V2 = styled.span`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
     background-color: #fff;
     color: #3535dc;
     border-radius: 5px;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    padding: 0 10px;
-    white-space: nowrap;
-`;
-
-const New = styled.span`
-    background-color: #3535dc;
-    color: #fff;
-    font-size: 10px;
-    font-weight: 700;
-    border-radius: 3px;
-    padding: 0 4px;
-    margin-left: 3px;
-    height: 13px;
-    display: flex;
-    align-items: center;
-    margin-bottom: -1px;
-    letter-spacing: 0;
 `;

--- a/components/Nav/Navbar/VersionToggle.tsx
+++ b/components/Nav/Navbar/VersionToggle.tsx
@@ -14,6 +14,7 @@ export const VersionToggle = ({ hideOnDesktop }: VersionToggleProps): JSX.Elemen
         if (router.route === '/') {
             return `${basePath}/pools`;
         } else {
+            // assumes that the destination base path appropriately handles redirects
             return `${basePath}${router.route}`;
         }
     }, [router.route]);

--- a/components/Nav/Navbar/VersionToggle.tsx
+++ b/components/Nav/Navbar/VersionToggle.tsx
@@ -1,18 +1,36 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { useRouter } from 'next/router';
 import styled from 'styled-components';
 
-export default (({ hideOnDesktop }) => (
-    <VersionToggle hideOnDesktop={hideOnDesktop}>
-        <V1 href="https://poolsv1.tracer.finance">V1</V1>
-        <V2>
-            V2 <New>BETA</New>
-        </V2>
-    </VersionToggle>
-)) as React.FC<{
+type VersionToggleProps = {
     hideOnDesktop?: boolean;
-}>;
+};
 
-const VersionToggle = styled.span<{ hideOnDesktop?: boolean }>`
+const basePath = 'https://poolsv1.tracer.finance';
+export const VersionToggle = ({ hideOnDesktop }: VersionToggleProps): JSX.Element => {
+    const router = useRouter();
+
+    const getRoute = useCallback(() => {
+        if (router.route === '/') {
+            return `${basePath}/pools`;
+        } else {
+            return `${basePath}${router.route}`;
+        }
+    }, [router.route]);
+
+    return (
+        <StyledVersionToggle hideOnDesktop={hideOnDesktop}>
+            <V1 href={getRoute()}>V1</V1>
+            <V2>
+                V2 <New>BETA</New>
+            </V2>
+        </StyledVersionToggle>
+    );
+};
+
+export default VersionToggle;
+
+const StyledVersionToggle = styled.span<{ hideOnDesktop?: boolean }>`
     border: 1px solid #fff;
     border-radius: 7px;
     background-color: rgba(255, 255, 255, 0.25);


### PR DESCRIPTION
Persist page route on version toggle. Page redirects assist in handling routes that differ between v1 and v2. Is in conjunction with https://github.com/tracer-protocol/pools-client/pull/659