### PR TITLE
Handle staked pool tokens

### DIFF
--- a/context/FarmContext/index.tsx
+++ b/context/FarmContext/index.tsx
@@ -132,8 +132,7 @@ export const FarmStore: React.FC = ({ children }) => {
                             return;
                         }
                         const poolDetails = {
-                            address: poolInfo.address,
-                            poolTokenPrice: (await fetchTokenPrice(poolInfo, [stakingTokenAddress], provider))[0],
+                            poolTokenPrice: await fetchTokenPrice(poolInfo, stakingTokenAddress, provider),
                         };
 
                         const stakingDecimalMultiplier = 10 ** stakingTokenDecimals;

--- a/context/FarmContext/index.tsx
+++ b/context/FarmContext/index.tsx
@@ -132,6 +132,7 @@ export const FarmStore: React.FC = ({ children }) => {
                             return;
                         }
                         const poolDetails = {
+                            address: poolInfo.address,
                             poolTokenPrice: (await fetchTokenPrice(poolInfo, [stakingTokenAddress], provider))[0],
                         };
 

--- a/hooks/useFarmBalances/index.tsx
+++ b/hooks/useFarmBalances/index.tsx
@@ -9,12 +9,10 @@ export const useFarmBalances = (): Record<string, BigNumber> => {
     return useMemo(
         () =>
             Object.values(farms).reduce((o, farm) => {
-                const totalPoolStaked = o[farm.poolDetails.address] ?? new BigNumber(0);
+                const totalPoolStaked = o[farm.stakingToken.address] ?? new BigNumber(0);
                 return {
                     ...o,
-                    [farm.poolDetails.address]: totalPoolStaked
-                        .plus(farm.myStaked)
-                        .times(farm.poolDetails.poolTokenPrice),
+                    [farm.stakingToken.address]: totalPoolStaked.plus(farm.myStaked),
                 };
             }, {} as Record<string, BigNumber>),
         [farms],

--- a/hooks/useFarmBalances/index.tsx
+++ b/hooks/useFarmBalances/index.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import BigNumber from 'bignumber.js';
+import { useFarms } from '~/context/FarmContext';
+
+// gets farm totalStaked amount in settlementTokens
+export const useFarmBalances = (): Record<string, BigNumber> => {
+    const { farms } = useFarms();
+
+    return useMemo(
+        () =>
+            Object.values(farms).reduce((o, farm) => {
+                const totalPoolStaked = o[farm.poolDetails.address] ?? new BigNumber(0);
+                return {
+                    ...o,
+                    [farm.poolDetails.address]: totalPoolStaked
+                        .plus(farm.myStaked)
+                        .times(farm.poolDetails.poolTokenPrice),
+                };
+            }, {} as Record<string, BigNumber>),
+        [farms],
+    );
+};
+
+export default useFarmBalances;

--- a/hooks/usePortfolioOverview/index.tsx
+++ b/hooks/usePortfolioOverview/index.tsx
@@ -53,7 +53,9 @@ export const usePortfolioOverview = (): PortfolioOverview => {
                 const nextLongTokenPrice = poolInstance.getNextLongTokenPrice();
                 const nextShortTokenPrice = poolInstance.getNextShortTokenPrice();
 
-                const totalStaked: BigNumber = farmBalances[pool.poolInstance.address] ?? new BigNumber(0);
+                const shortStaked: BigNumber = farmBalances[pool.poolInstance.shortToken.address] ?? new BigNumber(0);
+                const longStaked: BigNumber = farmBalances[pool.poolInstance.longToken.address] ?? new BigNumber(0);
+                const totalStaked = shortStaked.times(nextShortTokenPrice).plus(longStaked.times(nextLongTokenPrice));
 
                 totalPortfolioValue = totalPortfolioValue
                     .plus(calcNotionalValue(shortTokenPrice, userBalances.shortToken.balance))

--- a/hooks/usePortfolioOverview/index.tsx
+++ b/hooks/usePortfolioOverview/index.tsx
@@ -7,12 +7,14 @@ import { useStore } from '~/store/main';
 import { selectUserPendingCommitAmounts } from '~/store/PendingCommitSlice';
 import { selectAccount } from '~/store/Web3Slice';
 import { calcPercentageDifference } from '~/utils/converters';
+import useFarmBalances from '../useFarmBalances';
 import usePools from '../usePools';
 
 export const usePortfolioOverview = (): PortfolioOverview => {
     const { pools } = usePools();
     const account = useStore(selectAccount);
     const poolPendingCommitAmounts = useStore(selectUserPendingCommitAmounts);
+    const farmBalances = useFarmBalances();
 
     const [portfolioOverview, setPortfolioOverview] = useState<PortfolioOverview>({
         totalPortfolioValue: new BigNumber(0),
@@ -51,6 +53,8 @@ export const usePortfolioOverview = (): PortfolioOverview => {
                 const nextLongTokenPrice = poolInstance.getNextLongTokenPrice();
                 const nextShortTokenPrice = poolInstance.getNextShortTokenPrice();
 
+                const totalStaked: BigNumber = farmBalances[pool.poolInstance.address] ?? new BigNumber(0);
+
                 totalPortfolioValue = totalPortfolioValue
                     .plus(calcNotionalValue(shortTokenPrice, userBalances.shortToken.balance))
                     .plus(calcNotionalValue(shortTokenPrice, userBalances.aggregateBalances.shortTokens))
@@ -62,13 +66,15 @@ export const usePortfolioOverview = (): PortfolioOverview => {
                     .plus(pendingAmounts.shortMint)
                     // not accurate but not sure how much it matters
                     .plus(calcNotionalValue(nextLongTokenPrice, pendingAmounts.longBurn))
-                    .plus(calcNotionalValue(nextShortTokenPrice, pendingAmounts.shortBurn));
+                    .plus(calcNotionalValue(nextShortTokenPrice, pendingAmounts.shortBurn))
+                    .minus(totalStaked);
 
                 totalSettlementSpend = totalSettlementSpend
                     .plus(totalLongMintSpend)
                     .plus(totalShortMintSpend)
                     .plus(pendingAmounts.longMint)
-                    .plus(pendingAmounts.shortMint);
+                    .plus(pendingAmounts.shortMint)
+                    .minus(totalStaked);
 
                 realisedProfit = realisedProfit.plus(totalShortBurnReceived).plus(totalLongBurnReceived);
             });
@@ -83,7 +89,7 @@ export const usePortfolioOverview = (): PortfolioOverview => {
                 unrealisedProfit: totalPortfolioValue.minus(totalSettlementSpend),
             });
         }
-    }, [pools, account, poolPendingCommitAmounts]);
+    }, [pools, account, poolPendingCommitAmounts, farmBalances]);
 
     return portfolioOverview;
 };

--- a/hooks/usePortfolioOverview/index.tsx
+++ b/hooks/usePortfolioOverview/index.tsx
@@ -71,12 +71,16 @@ export const usePortfolioOverview = (): PortfolioOverview => {
                     .plus(calcNotionalValue(nextShortTokenPrice, pendingAmounts.shortBurn))
                     .minus(totalStaked);
 
+                totalPortfolioValue = BigNumber.max(totalPortfolioValue, 0);
+
                 totalSettlementSpend = totalSettlementSpend
                     .plus(totalLongMintSpend)
                     .plus(totalShortMintSpend)
                     .plus(pendingAmounts.longMint)
                     .plus(pendingAmounts.shortMint)
                     .minus(totalStaked);
+
+                totalSettlementSpend = BigNumber.max(totalSettlementSpend, 0);
 
                 realisedProfit = realisedProfit.plus(totalShortBurnReceived).plus(totalLongBurnReceived);
             });

--- a/hooks/usePortfolioOverview/index.tsx
+++ b/hooks/usePortfolioOverview/index.tsx
@@ -53,8 +53,8 @@ export const usePortfolioOverview = (): PortfolioOverview => {
                 const nextLongTokenPrice = poolInstance.getNextLongTokenPrice();
                 const nextShortTokenPrice = poolInstance.getNextShortTokenPrice();
 
-                const shortStaked: BigNumber = farmBalances[pool.poolInstance.shortToken.address] ?? new BigNumber(0);
-                const longStaked: BigNumber = farmBalances[pool.poolInstance.longToken.address] ?? new BigNumber(0);
+                const shortStaked: BigNumber = farmBalances[poolInstance.shortToken.address] ?? new BigNumber(0);
+                const longStaked: BigNumber = farmBalances[poolInstance.longToken.address] ?? new BigNumber(0);
                 const totalStaked = shortStaked.times(nextShortTokenPrice).plus(longStaked.times(nextLongTokenPrice));
 
                 totalPortfolioValue = totalPortfolioValue
@@ -69,18 +69,13 @@ export const usePortfolioOverview = (): PortfolioOverview => {
                     // not accurate but not sure how much it matters
                     .plus(calcNotionalValue(nextLongTokenPrice, pendingAmounts.longBurn))
                     .plus(calcNotionalValue(nextShortTokenPrice, pendingAmounts.shortBurn))
-                    .minus(totalStaked);
-
-                totalPortfolioValue = BigNumber.max(totalPortfolioValue, 0);
+                    .plus(totalStaked);
 
                 totalSettlementSpend = totalSettlementSpend
                     .plus(totalLongMintSpend)
                     .plus(totalShortMintSpend)
                     .plus(pendingAmounts.longMint)
-                    .plus(pendingAmounts.shortMint)
-                    .minus(totalStaked);
-
-                totalSettlementSpend = BigNumber.max(totalSettlementSpend, 0);
+                    .plus(pendingAmounts.shortMint);
 
                 realisedProfit = realisedProfit.plus(totalShortBurnReceived).plus(totalLongBurnReceived);
             });

--- a/hooks/usePortfolioOverview/usePortfolioOverview.test.ts
+++ b/hooks/usePortfolioOverview/usePortfolioOverview.test.ts
@@ -139,49 +139,71 @@ describe('usePortfolioOverview hook', () => {
         expect(selectAccount as jest.Mock).toHaveBeenCalledTimes(1);
     }),
         it('handles partially staked', () => {
-            (usePools as jest.Mock).mockReturnValue(FILLED_INITIAL_STATE);
+            const stakedLongTokens = 5;
+            const stakedShortTokens = 0;
+            (usePools as jest.Mock).mockReturnValue({
+                pools: [
+                    {
+                        ...DEFAULT_POOLSTATE,
+                        poolInstance: TEST_POOL_INSTANCE,
+                        userBalances: {
+                            ...FIXED_BALANCES.userBalances,
+                            longToken: {
+                                balance: FIXED_BALANCES.userBalances.longToken.balance.minus(stakedLongTokens),
+                            },
+                            shortToken: {
+                                balance: FIXED_BALANCES.userBalances.shortToken.balance.minus(stakedShortTokens),
+                            },
+                        },
+                    },
+                ],
+            });
             (useFarmBalances as jest.Mock).mockReturnValue({
-                [MOCK_LONG_TOKEN]: new BigNumber(5),
-                [MOCK_SHORT_TOKEN]: new BigNumber(0),
+                [MOCK_LONG_TOKEN]: new BigNumber(stakedLongTokens),
+                [MOCK_SHORT_TOKEN]: new BigNumber(stakedShortTokens),
             });
 
             const { result } = renderHook(() => usePortfolioOverview());
 
-            expect(result.current.totalPortfolioValue.toNumber()).toBe(225 - 5);
+            expect(result.current.totalPortfolioValue.toNumber()).toBe(225);
             expect(result.current.unrealisedProfit.toNumber()).toBe(0);
             expect(result.current.realisedProfit.toNumber()).toBe(25);
             expect(result.current.portfolioDelta).toBe(0);
         });
     it('handles fully staked', () => {
-        (usePools as jest.Mock).mockReturnValue(FILLED_INITIAL_STATE);
+        const stakedLongTokens = 10;
+        const stakedShortTokens = 15;
+        (usePools as jest.Mock).mockReturnValue({
+            pools: [
+                {
+                    ...DEFAULT_POOLSTATE,
+                    poolInstance: TEST_POOL_INSTANCE,
+                    ...FIXED_BALANCES,
+                    userBalances: {
+                        ...FIXED_BALANCES.userBalances,
+                        longToken: {
+                            balance: FIXED_BALANCES.userBalances.longToken.balance.minus(stakedLongTokens),
+                        },
+                        shortToken: {
+                            balance: FIXED_BALANCES.userBalances.shortToken.balance.minus(stakedShortTokens),
+                        },
+                    },
+                },
+            ],
+        });
         (useFarmBalances as jest.Mock).mockReturnValue({
-            [MOCK_LONG_TOKEN]: new BigNumber(10),
-            [MOCK_SHORT_TOKEN]: new BigNumber(15),
+            [MOCK_LONG_TOKEN]: new BigNumber(stakedLongTokens),
+            [MOCK_SHORT_TOKEN]: new BigNumber(stakedShortTokens),
         });
 
         const { result } = renderHook(() => usePortfolioOverview());
 
-        expect(result.current.totalPortfolioValue.toNumber()).toBe(225 - 25);
+        expect(result.current.totalPortfolioValue.toNumber()).toBe(225);
         expect(result.current.unrealisedProfit.toNumber()).toBe(0);
         expect(result.current.realisedProfit.toNumber()).toBe(25);
         expect(result.current.portfolioDelta).toBe(0);
     });
-    it('handles over staked', () => {
-        // staking more tokens than have minted (have received from another wallet);
-        (usePools as jest.Mock).mockReturnValue(FILLED_INITIAL_STATE);
-        (useFarmBalances as jest.Mock).mockReturnValue({
-            [MOCK_LONG_TOKEN]: new BigNumber(0),
-            [MOCK_SHORT_TOKEN]: new BigNumber(10000),
-        });
-
-        const { result } = renderHook(() => usePortfolioOverview());
-
-        expect(result.current.totalPortfolioValue.toNumber()).toBe(0);
-        expect(result.current.unrealisedProfit.toNumber()).toBe(0);
-        expect(result.current.realisedProfit.toNumber()).toBe(25);
-        expect(result.current.portfolioDelta).toBe(0);
-    });
-    it('handles staked with 0 balances', () => {
+    it('handles over staked with 0 balances', () => {
         // staking more tokens than have minted (have received from another wallet);
         // (usePools as jest.Mock).mockReturnValue();
         (useFarmBalances as jest.Mock).mockReturnValue({
@@ -191,8 +213,8 @@ describe('usePortfolioOverview hook', () => {
 
         const { result } = renderHook(() => usePortfolioOverview());
 
-        expect(result.current.totalPortfolioValue.toNumber()).toBe(0);
-        expect(result.current.unrealisedProfit.toNumber()).toBe(0);
+        expect(result.current.totalPortfolioValue.toNumber()).toBe(300);
+        expect(result.current.unrealisedProfit.toNumber()).toBe(300);
         expect(result.current.realisedProfit.toNumber()).toBe(0);
         expect(result.current.portfolioDelta).toBe(0);
     });

--- a/hooks/usePortfolioOverview/usePortfolioOverview.test.ts
+++ b/hooks/usePortfolioOverview/usePortfolioOverview.test.ts
@@ -24,7 +24,8 @@ beforeEach(() => {
         ],
     });
     (useFarmBalances as jest.Mock).mockReturnValue({
-        [MOCK_POOL]: new BigNumber(0),
+        [MOCK_LONG_TOKEN]: new BigNumber(0),
+        [MOCK_SHORT_TOKEN]: new BigNumber(0),
     });
 });
 
@@ -33,11 +34,21 @@ afterEach(() => {
 });
 
 const MOCK_ACCOUNT = '0x9332e38f1a9BA964e166DE3eb5c637bc36cD4D27';
-const MOCK_POOL = '420_69';
+const MOCK_POOL = 'MOCK_420';
+const MOCK_LONG_TOKEN = 'LONG';
+const MOCK_SHORT_TOKEN = 'SHORT';
 
 const TEST_POOL_INSTANCE = {
     ...DEFAULT_POOLSTATE.poolInstance,
     address: MOCK_POOL,
+    longToken: {
+        ...DEFAULT_POOLSTATE.poolInstance.longToken,
+        address: MOCK_LONG_TOKEN,
+    },
+    shortToken: {
+        ...DEFAULT_POOLSTATE.poolInstance.shortToken,
+        address: MOCK_SHORT_TOKEN,
+    },
 };
 
 // base set filled state
@@ -130,12 +141,13 @@ describe('usePortfolioOverview hook', () => {
         it('handles partially staked', () => {
             (usePools as jest.Mock).mockReturnValue(FILLED_INITIAL_STATE);
             (useFarmBalances as jest.Mock).mockReturnValue({
-                [MOCK_POOL]: new BigNumber(10),
+                [MOCK_LONG_TOKEN]: new BigNumber(5),
+                [MOCK_SHORT_TOKEN]: new BigNumber(0),
             });
 
             const { result } = renderHook(() => usePortfolioOverview());
 
-            expect(result.current.totalPortfolioValue.toNumber()).toBe(225 - 10);
+            expect(result.current.totalPortfolioValue.toNumber()).toBe(225 - 5);
             expect(result.current.unrealisedProfit.toNumber()).toBe(0);
             expect(result.current.realisedProfit.toNumber()).toBe(25);
             expect(result.current.portfolioDelta).toBe(0);
@@ -143,7 +155,8 @@ describe('usePortfolioOverview hook', () => {
     it('handles fully staked', () => {
         (usePools as jest.Mock).mockReturnValue(FILLED_INITIAL_STATE);
         (useFarmBalances as jest.Mock).mockReturnValue({
-            [MOCK_POOL]: new BigNumber(25),
+            [MOCK_LONG_TOKEN]: new BigNumber(10),
+            [MOCK_SHORT_TOKEN]: new BigNumber(15),
         });
 
         const { result } = renderHook(() => usePortfolioOverview());
@@ -157,7 +170,8 @@ describe('usePortfolioOverview hook', () => {
         // staking more tokens than have minted (have received from another wallet);
         (usePools as jest.Mock).mockReturnValue(FILLED_INITIAL_STATE);
         (useFarmBalances as jest.Mock).mockReturnValue({
-            [MOCK_POOL]: new BigNumber(10000),
+            [MOCK_LONG_TOKEN]: new BigNumber(0),
+            [MOCK_SHORT_TOKEN]: new BigNumber(10000),
         });
 
         const { result } = renderHook(() => usePortfolioOverview());
@@ -177,7 +191,7 @@ describe('usePortfolioOverview hook', () => {
             shortBurnLongMint: new BigNumber(30), // should ignore flip amounts for total portfolio value
         };
         (selectUserPendingCommitAmounts as jest.Mock).mockReturnValue({
-            [MOCK_POOL]: {
+            [MOCK_POOL.toLowerCase()]: {
                 [MOCK_ACCOUNT]: mintAmounts,
             },
         });
@@ -197,7 +211,7 @@ describe('usePortfolioOverview hook', () => {
             // burning from thin air. RIP when people buy on secondary market;
             // this is burning all tokens in the wallet
             (selectUserPendingCommitAmounts as jest.Mock).mockReturnValue({
-                [MOCK_POOL]: {
+                [MOCK_POOL.toLowerCase()]: {
                     [MOCK_ACCOUNT]: {
                         longBurn: new BigNumber(15),
                         shortBurn: new BigNumber(10),
@@ -249,26 +263,4 @@ describe('usePortfolioOverview hook', () => {
         expect(result.current.realisedProfit.toNumber()).toBe(0);
         expect(result.current.portfolioDelta).toBe(0);
     });
-    // it('handles partially staked', () => {
-    // (usePools as jest.Mock).mockReturnValue(FILLED_INITIAL_STATE);
-
-    // const { result, rerender } = renderHook(() => usePortfolioOverview());
-
-    // token prices are $1 for the first case
-    // totalPortfolioValue summation of aggregateBalances (200), walletBalances (25), and pendingCommits (50)
-    // expect(result.current.totalPortfolioValue.toNumber()).toBe(225);
-    // expect(result.current.unrealisedProfit.toNumber()).toBe(0);
-    // expect(result.current.realisedProfit.toNumber()).toBe(25);
-    // expect(result.current.portfolioDelta).toBe(0);
-
-    // (usePools as jest.Mock).mockReturnValue(FILLED_INITIAL_STATE);
-
-    // const { result } = renderHook(() => usePortfolioOverview());
-
-    // $5 for each token
-    // expect(result.current.totalPortfolioValue.toNumber()).toBe(225 - 10);
-    // expect(result.current.unrealisedProfit.toNumber()).toBe(0);
-    // expect(result.current.realisedProfit.toNumber()).toBe(25);
-    // expect(result.current.portfolioDelta).toBe(0);
-    // })
 });

--- a/hooks/usePortfolioOverview/usePortfolioOverview.test.ts
+++ b/hooks/usePortfolioOverview/usePortfolioOverview.test.ts
@@ -176,10 +176,25 @@ describe('usePortfolioOverview hook', () => {
 
         const { result } = renderHook(() => usePortfolioOverview());
 
-        expect(result.current.totalPortfolioValue.toNumber()).toBe(225 - 10000);
+        expect(result.current.totalPortfolioValue.toNumber()).toBe(0);
         expect(result.current.unrealisedProfit.toNumber()).toBe(0);
         expect(result.current.realisedProfit.toNumber()).toBe(25);
-        expect(result.current.portfolioDelta).toBe(-0);
+        expect(result.current.portfolioDelta).toBe(0);
+    });
+    it('handles staked with 0 balances', () => {
+        // staking more tokens than have minted (have received from another wallet);
+        // (usePools as jest.Mock).mockReturnValue();
+        (useFarmBalances as jest.Mock).mockReturnValue({
+            [MOCK_LONG_TOKEN]: new BigNumber(200),
+            [MOCK_SHORT_TOKEN]: new BigNumber(100),
+        });
+
+        const { result } = renderHook(() => usePortfolioOverview());
+
+        expect(result.current.totalPortfolioValue.toNumber()).toBe(0);
+        expect(result.current.unrealisedProfit.toNumber()).toBe(0);
+        expect(result.current.realisedProfit.toNumber()).toBe(0);
+        expect(result.current.portfolioDelta).toBe(0);
     });
     it('handles mints', () => {
         const mintAmounts = {

--- a/pages/portfolio.tsx
+++ b/pages/portfolio.tsx
@@ -5,6 +5,7 @@ import Portfolio from '~/archetypes/Portfolio';
 import Footer from '~/components/Footer';
 import UnsupportedNetworkPopup from '~/components/General/UnsupportedNetworkPopup';
 import NavBar from '~/components/Nav/Navbar';
+import { FarmStore } from '~/context/FarmContext';
 import { SwapStore } from '~/context/SwapContext';
 
 export default (() => {
@@ -29,7 +30,9 @@ export default (() => {
         <div className={`page relative matrix:bg-matrix-bg`} ref={ref}>
             <NavBar />
             <SwapStore>
-                <Portfolio />
+                <FarmStore>
+                    <Portfolio />
+                </FarmStore>
             </SwapStore>
             <UnsupportedNetworkPopup />
             <Footer />

--- a/types/staking/index.ts
+++ b/types/staking/index.ts
@@ -16,7 +16,6 @@ export type FarmTableDetails = {
     link?: string;
     linkText?: string;
     poolDetails: {
-        address: string;
         poolTokenPrice: BigNumber;
     };
 };

--- a/types/staking/index.ts
+++ b/types/staking/index.ts
@@ -16,6 +16,7 @@ export type FarmTableDetails = {
     link?: string;
     linkText?: string;
     poolDetails: {
+        address: string;
         poolTokenPrice: BigNumber;
     };
 };

--- a/utils/farms.ts
+++ b/utils/farms.ts
@@ -4,11 +4,11 @@ import Pool, { StaticPoolInfo } from '@tracer-protocol/pools-js/entities/pool';
 
 export const fetchTokenPrice: (
     poolInfo: StaticPoolInfo,
-    tokenAddresses: [string] | [string, string],
+    tokenAddress: string,
     provider: ethers.providers.JsonRpcProvider | undefined,
-) => Promise<BigNumber[]> = async (poolInfo_, tokenAddresses, provider) => {
+) => Promise<BigNumber> = async (poolInfo_, tokenAddress, provider) => {
     if (!provider || !poolInfo_) {
-        return [new BigNumber(1), new BigNumber(1)];
+        return new BigNumber(1);
     }
 
     try {
@@ -17,12 +17,10 @@ export const fetchTokenPrice: (
             provider,
         });
 
-        return tokenAddresses.map((tokenAddress) => {
-            const isLong: boolean = tokenAddress.toLowerCase() === poolInfo.longToken.address.toLowerCase();
-            return isLong ? poolInfo.getNextLongTokenPrice() : poolInfo.getNextShortTokenPrice();
-        });
+        const isLong: boolean = tokenAddress.toLowerCase() === poolInfo.longToken.address.toLowerCase();
+        return isLong ? poolInfo.getNextLongTokenPrice() : poolInfo.getNextShortTokenPrice();
     } catch (err) {
         console.error('Failed to fetch farm token prices');
-        return [new BigNumber(1), new BigNumber(1)];
+        return new BigNumber(1);
     }
 };


### PR DESCRIPTION
Handle staked pool tokens on portfolio page. Uses pool token amounts such that the token price matches the token price used on the portfolio page. Creates a mapping from token address to staked balances. Uses this mapping in usePortfolioOverview to add staked token amounts to the users portfolio. Acts as if the tokens were not staked and are still in wallet balance. This is because totalSettlement spend does not change after staking but wallet balances do, so adding the staked amount replaces the losses in wallet balance