### PR TITLE
Dev 263 add stake button

### DIFF
--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
@@ -5,17 +5,13 @@ import { TableRow } from '~/components/General/TWTable';
 import Actions from '~/components/TokenActions';
 import UpOrDown from '~/components/UpOrDown';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
+import { ClaimedRowActions, ClaimedTokenRowProps } from '~/types/claimedTokens';
 import { Market } from '../Market';
 import { ActionsButton, ActionsCell } from '../OverviewTable/styles';
 import { OverviewTableRowCell } from '../OverviewTable/styles';
-import { OnClickCommit, TokenRowProps } from '../state';
 import { TokensNotional } from '../Tokens';
 
-export const ClaimedTokenRow: React.FC<
-    TokenRowProps & {
-        onClickCommitAction: OnClickCommit;
-    }
-> = ({
+export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions> = ({
     symbol,
     address,
     poolAddress,
@@ -25,8 +21,10 @@ export const ClaimedTokenRow: React.FC<
     balance,
     currentTokenPrice,
     onClickCommitAction,
+    onClickStake,
     leveragedNotionalValue,
     entryPrice,
+    stakedTokens,
 }) => {
     return (
         <TableRow lined>
@@ -56,6 +54,14 @@ export const ClaimedTokenRow: React.FC<
                 <div>{`${leveragedNotionalValue.toFixed(3)} ${settlementTokenSymbol}`}</div>
             </OverviewTableRowCell>
             <ActionsCell>
+                <ActionsButton
+                    size="xs"
+                    variant="primary-light"
+                    disabled={!balance.toNumber()}
+                    onClick={() => onClickStake(address)}
+                >
+                    {stakedTokens.eq(0) || !stakedTokens.eq(balance) ? 'Stake' : 'Unstake'}
+                </ActionsButton>
                 <ActionsButton
                     size="xs"
                     variant="primary-light"

--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
@@ -24,8 +24,9 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
     onClickStake,
     leveragedNotionalValue,
     entryPrice,
-    stakedTokens,
 }) => {
+    // if there is any balance at all they should stake
+    const shouldStake = !balance.eq(0);
     return (
         <TableRow lined>
             <OverviewTableRowCell>
@@ -57,10 +58,10 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
                 <ActionsButton
                     size="xs"
                     variant="primary-light"
-                    disabled={!balance.toNumber()}
-                    onClick={() => onClickStake(address)}
+                    // will never be disabled if it gets included as a row it will always be either to stake or to unstake
+                    onClick={() => onClickStake(address, shouldStake ? 'stake' : 'unstake')}
                 >
-                    {stakedTokens.eq(0) || !stakedTokens.eq(balance) ? 'Stake' : 'Unstake'}
+                    {shouldStake ? 'Stake' : 'Unstake'}
                 </ActionsButton>
                 <ActionsButton
                     size="xs"

--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokensTable.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokensTable.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import NoTableEntries from '~/components/General/NoTableEntries';
 import { Table, TableHeader, TableHeaderCell } from '~/components/General/TWTable';
+import { ClaimedRowActions, ClaimedTokenRowProps } from '~/types/claimedTokens';
 import { ClaimedTokenRow } from './ClaimedTokenRow';
-import { OnClickCommit, TokenRowProps } from '../state';
 
 export const ClaimedTokensTable = ({
     rows,
     onClickCommitAction,
+    onClickStake,
 }: {
-    rows: TokenRowProps[];
-    onClickCommitAction: OnClickCommit;
-}): JSX.Element => {
+    rows: ClaimedTokenRowProps[];
+} & ClaimedRowActions): JSX.Element => {
     return (
         <>
             <Table fullHeight={false}>
@@ -29,7 +29,12 @@ export const ClaimedTokensTable = ({
                         <NoTableEntries>You have no claimed tokens.</NoTableEntries>
                     ) : (
                         rows.map((token) => (
-                            <ClaimedTokenRow {...token} key={token.address} onClickCommitAction={onClickCommitAction} />
+                            <ClaimedTokenRow
+                                {...token}
+                                key={token.address}
+                                onClickCommitAction={onClickCommitAction}
+                                onClickStake={onClickStake}
+                            />
                         ))
                     )}
                 </tbody>

--- a/archetypes/Portfolio/ClaimedTokensTable/index.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/index.tsx
@@ -1,27 +1,28 @@
 import React, { useMemo } from 'react';
 import useUserClaimedTokens from '~/hooks/useUserClaimedTokens';
+import { ClaimedRowActions, ClaimedTokenRowProps } from '~/types/claimedTokens';
 import { MarketFilterEnum } from '~/types/filters';
 import { generalMarketFilter } from '~/utils/filters';
 import { escapeRegExp } from '~/utils/helpers';
 import { ClaimedTokensTable } from './ClaimedTokensTable';
 import { OverviewTable } from '../OverviewTable';
 import { MarketDropdown, OverviewTableSearch } from '../OverviewTable/Actions';
-import { OnClickCommit, PortfolioAction, PortfolioState, TokenRowProps } from '../state';
+import { PortfolioAction, PortfolioState } from '../state';
 
 export const ClaimedTokens = ({
     claimedTokensMarketFilter,
     claimedTokensSearch,
     dispatch,
     onClickCommitAction,
+    onClickStake,
 }: {
     claimedTokensMarketFilter: PortfolioState['claimedTokensMarketFilter'];
     claimedTokensSearch: PortfolioState['claimedTokensSearch'];
     dispatch: React.Dispatch<PortfolioAction>;
-    onClickCommitAction: OnClickCommit;
-}): JSX.Element => {
+} & ClaimedRowActions): JSX.Element => {
     const { rows: tokens, isLoading } = useUserClaimedTokens();
 
-    const claimedSearchFilter = (token: TokenRowProps): boolean => {
+    const claimedSearchFilter = (token: ClaimedTokenRowProps): boolean => {
         const searchString = escapeRegExp(claimedTokensSearch.toLowerCase());
         return Boolean(token.name.toLowerCase().match(searchString));
     };
@@ -56,7 +57,11 @@ export const ClaimedTokens = ({
             isLoading={isLoading}
             rowCount={tokens.length}
         >
-            <ClaimedTokensTable rows={filteredTokens} onClickCommitAction={onClickCommitAction} />
+            <ClaimedTokensTable
+                rows={filteredTokens}
+                onClickCommitAction={onClickCommitAction}
+                onClickStake={onClickStake}
+            />
         </OverviewTable>
     );
 };

--- a/archetypes/Portfolio/TradeOverviewBanner/index.tsx
+++ b/archetypes/Portfolio/TradeOverviewBanner/index.tsx
@@ -4,7 +4,7 @@ import { Heading } from '~/components/PageTable';
 import { toApproxCurrency, toApproxLocaleString } from '~/utils/converters';
 import * as Styles from './styles';
 import { ConnectWalletBanner } from '../ConnectWalletBanner';
-import { PortfolioOverview } from '../state';
+import { PortfolioOverview } from '~/types/portfolio';
 
 type BannerTypes = {
     title: string;

--- a/archetypes/Portfolio/TradeOverviewBanner/index.tsx
+++ b/archetypes/Portfolio/TradeOverviewBanner/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { NetworkHintContainer, NetworkHint } from '~/components/NetworkHint';
 import { Heading } from '~/components/PageTable';
+import { PortfolioOverview } from '~/types/portfolio';
 import { toApproxCurrency, toApproxLocaleString } from '~/utils/converters';
 import * as Styles from './styles';
 import { ConnectWalletBanner } from '../ConnectWalletBanner';
-import { PortfolioOverview } from '~/types/portfolio';
 
 type BannerTypes = {
     title: string;

--- a/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensRows.tsx
+++ b/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensRows.tsx
@@ -5,12 +5,13 @@ import { TableRow } from '~/components/General/TWTable';
 import Actions from '~/components/TokenActions';
 import UpOrDown from '~/components/UpOrDown';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
+import { OverviewAsset } from '~/types/portfolio';
+import { UnclaimedPoolTokenRowProps } from '~/types/unclaimedTokens';
 import { Market, SettlementToken } from '../Market';
 import { OverviewTableRowCell, ActionsCell, ActionsButton } from '../OverviewTable/styles';
-import { OverviewAsset, ClaimablePoolTokenRowProps } from '../state';
 import { TokensNotional } from '../Tokens';
 
-export const ClaimablePoolTokenRow: React.FC<ClaimablePoolTokenRowProps & { settlementTokenSymbol: string }> = ({
+export const UnclaimedPoolTokenRow = ({
     balance,
     leveragedNotionalValue,
     entryPrice,
@@ -22,7 +23,7 @@ export const ClaimablePoolTokenRow: React.FC<ClaimablePoolTokenRowProps & { sett
     side,
     poolAddress,
     settlementTokenSymbol,
-}) => {
+}: UnclaimedPoolTokenRowProps): JSX.Element => {
     return (
         <TableRow>
             <OverviewTableRowCell>
@@ -83,7 +84,7 @@ export const ClaimablePoolTokenRow: React.FC<ClaimablePoolTokenRowProps & { sett
     );
 };
 
-export const ClaimableQuoteTokenRow: React.FC<OverviewAsset> = ({ symbol, balance, address, decimals }) => (
+export const UnclaimedQuoteTokenRow = ({ symbol, balance, address, decimals }: OverviewAsset): JSX.Element => (
     <TableRow>
         <OverviewTableRowCell>
             <SettlementToken tokenSymbol={symbol} />

--- a/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensTable.tsx
+++ b/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensTable.tsx
@@ -4,17 +4,18 @@ import NoTableEntries from '~/components/General/NoTableEntries';
 import { Table, TableHeader, TableHeaderCell } from '~/components/General/TWTable';
 import { usePoolInstanceActions } from '~/hooks/usePoolInstanceActions';
 
+import { OverviewPoolToken } from '~/types/portfolio';
+import { UnclaimedRowInfo, UnclaimedRowProps, UnclaimedRowActions } from '~/types/unclaimedTokens';
+import {TokenType} from '../state';
 import * as Styles from './styles';
-import { ClaimableQuoteTokenRow, ClaimablePoolTokenRow } from './UnclaimedTokensRows';
-import { UnclaimedRowInfo, OverviewPoolToken, TokenType, UnclaimedRowProps, OnClickCommit } from '../state';
+import { UnclaimedQuoteTokenRow, UnclaimedPoolTokenRow } from './UnclaimedTokensRows';
 
 export const UnclaimedTokensTable = ({
     rows,
     onClickCommitAction,
 }: {
     rows: UnclaimedRowInfo[];
-    onClickCommitAction: OnClickCommit;
-}): JSX.Element => {
+} & UnclaimedRowActions): JSX.Element => {
     return (
         <>
             <Table>
@@ -90,7 +91,7 @@ const PoolRow = ({
                 if (claimableAsset.type === TokenType.Settlement) {
                     return (
                         !claimableAsset.balance.eq(0) && (
-                            <ClaimableQuoteTokenRow
+                            <UnclaimedQuoteTokenRow
                                 key={`${poolAddress}-${claimableAsset.symbol}`}
                                 {...claimableAsset}
                             />
@@ -99,7 +100,7 @@ const PoolRow = ({
                 } else {
                     return (
                         !claimableAsset.balance.eq(0) && (
-                            <ClaimablePoolTokenRow
+                            <UnclaimedPoolTokenRow
                                 key={`${poolAddress}-${claimableAsset.symbol}`}
                                 poolAddress={poolAddress}
                                 onClickCommitAction={onClickCommitAction}

--- a/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensTable.tsx
+++ b/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensTable.tsx
@@ -6,9 +6,9 @@ import { usePoolInstanceActions } from '~/hooks/usePoolInstanceActions';
 
 import { OverviewPoolToken } from '~/types/portfolio';
 import { UnclaimedRowInfo, UnclaimedRowProps, UnclaimedRowActions } from '~/types/unclaimedTokens';
-import {TokenType} from '../state';
 import * as Styles from './styles';
 import { UnclaimedQuoteTokenRow, UnclaimedPoolTokenRow } from './UnclaimedTokensRows';
+import { TokenType } from '../state';
 
 export const UnclaimedTokensTable = ({
     rows,

--- a/archetypes/Portfolio/UnclaimedTokens/index.tsx
+++ b/archetypes/Portfolio/UnclaimedTokens/index.tsx
@@ -1,12 +1,13 @@
 import React, { useMemo } from 'react';
 import useUserUnclaimedTokens from '~/hooks/useUserUnclaimedTokens';
 import { MarketFilterEnum } from '~/types/filters';
+import { UnclaimedRowActions, UnclaimedRowInfo } from '~/types/unclaimedTokens';
 import { marketFilter } from '~/utils/filters';
 import { escapeRegExp } from '~/utils/helpers';
 import { UnclaimedTokensTable } from './UnclaimedTokensTable';
 import { OverviewTable } from '../OverviewTable';
 import { MarketDropdown, OverviewTableSearch } from '../OverviewTable/Actions';
-import { OnClickCommit, PortfolioAction, PortfolioState, UnclaimedRowInfo } from '../state';
+import { PortfolioAction, PortfolioState } from '../state';
 
 export const UnclaimedTokens = ({
     escrowMarketFilter,
@@ -17,8 +18,7 @@ export const UnclaimedTokens = ({
     escrowMarketFilter: PortfolioState['escrowMarketFilter'];
     escrowSearch: PortfolioState['escrowSearch'];
     dispatch: React.Dispatch<PortfolioAction>;
-    onClickCommitAction: OnClickCommit;
-}): JSX.Element => {
+} & UnclaimedRowActions): JSX.Element => {
     const { rows: escrowRows, isLoading } = useUserUnclaimedTokens();
     const totalClaimable = useMemo(
         () => escrowRows.reduce((count, pool) => count + pool.numClaimable, 0),

--- a/archetypes/Portfolio/index.tsx
+++ b/archetypes/Portfolio/index.tsx
@@ -1,4 +1,5 @@
 import React, { useReducer, useState } from 'react';
+import { useRouter } from 'next/router';
 import { BalanceTypeEnum } from '@tracer-protocol/pools-js';
 import MintBurnModal from '~/archetypes/Pools/MintBurnModal';
 import Divider from '~/components/General/Divider';
@@ -8,6 +9,7 @@ import usePortfolioOverview from '~/hooks/usePortfolioOverview';
 import { useStore } from '~/store/main';
 import { selectAccount, selectHandleConnect } from '~/store/Web3Slice';
 
+import { OnClickCommit, OnClickStake } from '~/types/portfolio';
 import { ClaimedTokens } from './ClaimedTokensTable';
 import { emptyStateHelpCardContent } from './content';
 import { HelpCard } from './HelpCard';
@@ -19,9 +21,9 @@ import { Container } from './styles';
 import * as Styles from './styles';
 import { TradeOverviewBanner } from './TradeOverviewBanner';
 import UnclaimedTokens from './UnclaimedTokens';
-import {OnClickCommit, OnClickStake} from '~/types/portfolio';
 
 export const PortfolioPage = (): JSX.Element => {
+    const router = useRouter();
     const account = useStore(selectAccount);
     const handleConnect = useStore(selectHandleConnect);
     const { swapDispatch = noDispatch } = useSwapContext();
@@ -38,8 +40,13 @@ export const PortfolioPage = (): JSX.Element => {
         setMintBurnModalOpen(true);
     };
 
-    const onClickStake: OnClickStake = (token: string) => {
-        console.log(token);
+    const onClickStake: OnClickStake = (token: string, stakeAction: 'stake' | 'unstake') => {
+        router.push({
+            pathname: '/stake',
+            query: {
+                [stakeAction]: token,
+            },
+        });
     };
 
     const handleModalClose = () => {

--- a/archetypes/Portfolio/index.tsx
+++ b/archetypes/Portfolio/index.tsx
@@ -14,11 +14,12 @@ import { HelpCard } from './HelpCard';
 import HistoricCommits from './HistoricCommits';
 import QueuedCommits from './QueuedCommits';
 import { SkewCard } from './SkewCard';
-import { portfolioReducer, initialPortfolioState, OnClickCommit } from './state';
+import { portfolioReducer, initialPortfolioState } from './state';
 import { Container } from './styles';
 import * as Styles from './styles';
 import { TradeOverviewBanner } from './TradeOverviewBanner';
 import UnclaimedTokens from './UnclaimedTokens';
+import {OnClickCommit, OnClickStake} from '~/types/portfolio';
 
 export const PortfolioPage = (): JSX.Element => {
     const account = useStore(selectAccount);
@@ -35,6 +36,10 @@ export const PortfolioPage = (): JSX.Element => {
         swapDispatch({ type: 'setSide', value: side });
         swapDispatch({ type: 'setCommitAction', value: action });
         setMintBurnModalOpen(true);
+    };
+
+    const onClickStake: OnClickStake = (token: string) => {
+        console.log(token);
     };
 
     const handleModalClose = () => {
@@ -89,6 +94,7 @@ export const PortfolioPage = (): JSX.Element => {
                     claimedTokensSearch={state.claimedTokensSearch}
                     dispatch={dispatch}
                     onClickCommitAction={onClickCommitAction}
+                    onClickStake={onClickStake}
                 />
                 <UnclaimedTokens
                     escrowSearch={state.escrowSearch}

--- a/archetypes/Portfolio/state.ts
+++ b/archetypes/Portfolio/state.ts
@@ -1,6 +1,3 @@
-import BigNumber from 'bignumber.js';
-import { CommitActionEnum, SideEnum } from '@tracer-protocol/pools-js';
-import { LogoTicker } from '~/components/General';
 import { MarketFilterEnum } from '~/types/filters';
 
 export enum DenotedInEnum {
@@ -28,58 +25,7 @@ export enum OverviewPageFocus {
     History = 'history',
 }
 
-export type PortfolioOverview = {
-    totalPortfolioValue: BigNumber;
-    unrealisedProfit: BigNumber;
-    realisedProfit: BigNumber;
-    portfolioDelta: number; //percentage change
-};
-
-export type TokenRowProps = Omit<OverviewPoolToken, 'type'> & {
-    name: string;
-    poolAddress: string;
-    settlementTokenSymbol: string;
-    oraclePrice: BigNumber;
-    effectiveGain: number;
-};
-
-export type OnClickCommit = (pool: string, side: SideEnum, action: CommitActionEnum, unclaimed?: boolean) => void;
-
-export type UnclaimedRowProps = UnclaimedRowInfo & {
-    onClickCommitAction: OnClickCommit;
-};
-
-export type UnclaimedRowInfo = {
-    poolName: string; // pool name
-    poolAddress: string;
-    marketTicker: LogoTicker;
-    claimableLongTokens: OverviewPoolToken;
-    claimableShortTokens: OverviewPoolToken;
-    claimableSettlementTokens: OverviewAsset;
-    claimableSum: BigNumber;
-    numClaimable: number;
-};
-
-export type OverviewAsset = {
-    symbol: string;
-    balance: BigNumber;
-    address: string;
-    decimals: number;
-    currentTokenPrice: BigNumber;
-    type: TokenType;
-    leveragedNotionalValue: BigNumber;
-};
-
-export type OverviewPoolToken = {
-    entryPrice: BigNumber;
-    side: SideEnum;
-} & OverviewAsset;
-
-export type ClaimablePoolTokenRowProps = OverviewPoolToken & {
-    poolAddress: UnclaimedRowProps['poolAddress'];
-    onClickCommitAction: OnClickCommit;
-};
-
+/* State */
 export interface PortfolioState {
     escrowSearch: string;
     escrowMarketFilter: MarketFilterEnum;

--- a/constants/pools.ts
+++ b/constants/pools.ts
@@ -82,7 +82,7 @@ export const POOL_LIST_MAP: TokenListMapByNetwork = {
     },
     [NETWORKS.ARBITRUM_RINKEBY]: {
         Tracer: {
-            verified: 'https://api.tracer.finance/poolsv2/poolList?network=421611',
+            verified: 'https://dev.api.tracer.finance/poolsv2/poolList?network=421611',
         },
         External: [],
     },

--- a/hooks/usePortfolioOverview/index.tsx
+++ b/hooks/usePortfolioOverview/index.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import BigNumber from 'bignumber.js';
 import { calcNotionalValue } from '@tracer-protocol/pools-js';
-import { PortfolioOverview } from '~/types/portfolio';
 import { DEFAULT_PENDING_COMMIT_AMOUNTS } from '~/constants/commits';
 import { useStore } from '~/store/main';
 import { selectUserPendingCommitAmounts } from '~/store/PendingCommitSlice';
 import { selectAccount } from '~/store/Web3Slice';
+import { PortfolioOverview } from '~/types/portfolio';
 import { calcPercentageDifference } from '~/utils/converters';
 import useFarmBalances from '../useFarmBalances';
 import usePools from '../usePools';

--- a/hooks/usePortfolioOverview/index.tsx
+++ b/hooks/usePortfolioOverview/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import BigNumber from 'bignumber.js';
 import { calcNotionalValue } from '@tracer-protocol/pools-js';
-import { PortfolioOverview } from '~/archetypes/Portfolio/state';
+import { PortfolioOverview } from '~/types/portfolio';
 import { DEFAULT_PENDING_COMMIT_AMOUNTS } from '~/constants/commits';
 import { useStore } from '~/store/main';
 import { selectUserPendingCommitAmounts } from '~/store/PendingCommitSlice';

--- a/hooks/useUserClaimedTokens/index.tsx
+++ b/hooks/useUserClaimedTokens/index.tsx
@@ -1,18 +1,20 @@
 import { useState, useEffect } from 'react';
 import { BigNumber } from 'bignumber.js';
 import { calcEffectiveLongGain, calcEffectiveShortGain, calcNotionalValue } from '@tracer-protocol/pools-js';
-import { TokenRowProps } from '~/archetypes/Portfolio//state';
+import { ClaimedTokenRowProps } from '~/types/claimedTokens';
 import { usePools } from '~/hooks/usePools';
 import { LoadingRows } from '~/types/hooks';
+import useFarmBalances from '../useFarmBalances';
 
-export const useUserClaimedTokens = (): LoadingRows<TokenRowProps> => {
+export const useUserClaimedTokens = (): LoadingRows<ClaimedTokenRowProps> => {
     const { pools, isLoadingPools } = usePools();
-    const [rows, setRows] = useState<TokenRowProps[]>([]);
+    const farmBalances = useFarmBalances();
+    const [rows, setRows] = useState<ClaimedTokenRowProps[]>([]);
 
     useEffect(() => {
         if (pools) {
             const poolValues = Object.values(pools);
-            const tokens: TokenRowProps[] = [];
+            const tokens: ClaimedTokenRowProps[] = [];
 
             poolValues.forEach((pool) => {
                 const { poolInstance, userBalances } = pool;
@@ -26,7 +28,10 @@ export const useUserClaimedTokens = (): LoadingRows<TokenRowProps> => {
                 const shortTokenPrice = poolInstance.getShortTokenPrice();
                 const shortNotionalValue = calcNotionalValue(shortTokenPrice, userBalances.shortToken.balance);
 
-                if (!userBalances.shortToken.balance.eq(0)) {
+                const shortStaked: BigNumber = farmBalances[poolInstance.shortToken.address] ?? new BigNumber(0);
+                const longStaked: BigNumber = farmBalances[poolInstance.longToken.address] ?? new BigNumber(0);
+
+                if (!userBalances.shortToken.balance.eq(0) || !shortStaked.eq(0)) {
                     tokens.push({
                         name: shortToken.name,
                         poolAddress: address,
@@ -41,9 +46,10 @@ export const useUserClaimedTokens = (): LoadingRows<TokenRowProps> => {
                         effectiveGain: calcEffectiveShortGain(shortBalance, longBalance, leverageBN).toNumber(),
                         entryPrice: userBalances.tradeStats.avgShortEntryPriceWallet,
                         settlementTokenSymbol: poolInstance.settlementToken.symbol,
+                        stakedTokens: shortStaked,
                     });
                 }
-                if (!userBalances.longToken.balance.eq(0)) {
+                if (!userBalances.longToken.balance.eq(0) || !longStaked.eq(0)) {
                     tokens.push({
                         name: longToken.name,
                         poolAddress: address,
@@ -58,13 +64,14 @@ export const useUserClaimedTokens = (): LoadingRows<TokenRowProps> => {
                         effectiveGain: calcEffectiveLongGain(longBalance, longBalance, leverageBN).toNumber(),
                         entryPrice: userBalances.tradeStats.avgLongEntryPriceWallet,
                         settlementTokenSymbol: poolInstance.settlementToken.symbol,
+                        stakedTokens: longStaked,
                     });
                 }
             });
 
             setRows(tokens);
         }
-    }, [pools]);
+    }, [pools, farmBalances]);
 
     return {
         rows,

--- a/hooks/useUserClaimedTokens/index.tsx
+++ b/hooks/useUserClaimedTokens/index.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
 import { BigNumber } from 'bignumber.js';
 import { calcEffectiveLongGain, calcEffectiveShortGain, calcNotionalValue } from '@tracer-protocol/pools-js';
-import { ClaimedTokenRowProps } from '~/types/claimedTokens';
 import { usePools } from '~/hooks/usePools';
+import { ClaimedTokenRowProps } from '~/types/claimedTokens';
 import { LoadingRows } from '~/types/hooks';
 import useFarmBalances from '../useFarmBalances';
 

--- a/hooks/useUserUnclaimedTokens/index.ts
+++ b/hooks/useUserUnclaimedTokens/index.ts
@@ -2,10 +2,10 @@ import { useEffect, useState } from 'react';
 import { BigNumber } from 'bignumber.js';
 import { calcNotionalValue, SideEnum } from '@tracer-protocol/pools-js';
 import { TokenType } from '~/archetypes/Portfolio/state';
-import { UnclaimedRowInfo } from '~/types/unclaimedTokens';
 import { LogoTicker } from '~/components/General';
 import { usePools } from '~/hooks/usePools';
 import { LoadingRows } from '~/types/hooks';
+import { UnclaimedRowInfo } from '~/types/unclaimedTokens';
 import { getBaseAsset } from '~/utils/poolNames';
 
 export const useUserUnclaimedTokens = (): LoadingRows<UnclaimedRowInfo> => {

--- a/hooks/useUserUnclaimedTokens/index.ts
+++ b/hooks/useUserUnclaimedTokens/index.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { BigNumber } from 'bignumber.js';
 import { calcNotionalValue, SideEnum } from '@tracer-protocol/pools-js';
-import { UnclaimedRowInfo, TokenType } from '~/archetypes/Portfolio/state';
+import { TokenType } from '~/archetypes/Portfolio/state';
+import { UnclaimedRowInfo } from '~/types/unclaimedTokens';
 import { LogoTicker } from '~/components/General';
 import { usePools } from '~/hooks/usePools';
 import { LoadingRows } from '~/types/hooks';

--- a/types/claimedTokens.ts
+++ b/types/claimedTokens.ts
@@ -1,0 +1,17 @@
+import BigNumber from 'bignumber.js';
+import { OnClickCommit, OnClickStake, OverviewPoolToken } from './portfolio';
+
+/* Claimed tokens */
+export type ClaimedRowActions = {
+    onClickCommitAction: OnClickCommit;
+    onClickStake: OnClickStake;
+};
+
+export type ClaimedTokenRowProps = Omit<OverviewPoolToken, 'type'> & {
+    name: string;
+    poolAddress: string;
+    settlementTokenSymbol: string;
+    oraclePrice: BigNumber;
+    effectiveGain: number;
+    stakedTokens: BigNumber;
+};

--- a/types/claimedTokens.ts
+++ b/types/claimedTokens.ts
@@ -1,7 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { OnClickCommit, OnClickStake, OverviewPoolToken } from './portfolio';
 
-/* Claimed tokens */
 export type ClaimedRowActions = {
     onClickCommitAction: OnClickCommit;
     onClickStake: OnClickStake;

--- a/types/portfolio.ts
+++ b/types/portfolio.ts
@@ -12,7 +12,6 @@ export type PortfolioOverview = {
 export type OnClickStake = (token: string, action: 'stake' | 'unstake') => void;
 export type OnClickCommit = (pool: string, side: SideEnum, action: CommitActionEnum, unclaimed?: boolean) => void;
 
-/* General Overview types */
 export type OverviewAsset = {
     symbol: string;
     balance: BigNumber;

--- a/types/portfolio.ts
+++ b/types/portfolio.ts
@@ -1,0 +1,29 @@
+import BigNumber from 'bignumber.js';
+import { CommitActionEnum, SideEnum } from '@tracer-protocol/pools-js';
+import { TokenType } from '~/archetypes/Portfolio/state';
+
+export type PortfolioOverview = {
+    totalPortfolioValue: BigNumber;
+    unrealisedProfit: BigNumber;
+    realisedProfit: BigNumber;
+    portfolioDelta: number; //percentage change
+};
+
+export type OnClickStake = (token: string) => void;
+export type OnClickCommit = (pool: string, side: SideEnum, action: CommitActionEnum, unclaimed?: boolean) => void;
+
+/* General Overview types */
+export type OverviewAsset = {
+    symbol: string;
+    balance: BigNumber;
+    address: string;
+    decimals: number;
+    currentTokenPrice: BigNumber;
+    type: TokenType;
+    leveragedNotionalValue: BigNumber;
+};
+
+export type OverviewPoolToken = {
+    entryPrice: BigNumber;
+    side: SideEnum;
+} & OverviewAsset;

--- a/types/portfolio.ts
+++ b/types/portfolio.ts
@@ -9,7 +9,7 @@ export type PortfolioOverview = {
     portfolioDelta: number; //percentage change
 };
 
-export type OnClickStake = (token: string) => void;
+export type OnClickStake = (token: string, action: 'stake' | 'unstake') => void;
 export type OnClickCommit = (pool: string, side: SideEnum, action: CommitActionEnum, unclaimed?: boolean) => void;
 
 /* General Overview types */

--- a/types/unclaimedTokens.ts
+++ b/types/unclaimedTokens.ts
@@ -1,0 +1,26 @@
+import BigNumber from 'bignumber.js';
+import { LogoTicker } from '~/components/General';
+import { OnClickCommit, OverviewAsset, OverviewPoolToken } from './portfolio';
+
+/* Unclaimed tokens */
+export type UnclaimedRowActions = {
+    onClickCommitAction: OnClickCommit;
+};
+export type UnclaimedRowInfo = {
+    poolName: string; // pool name
+    poolAddress: string;
+    marketTicker: LogoTicker;
+    claimableLongTokens: OverviewPoolToken;
+    claimableShortTokens: OverviewPoolToken;
+    claimableSettlementTokens: OverviewAsset;
+    claimableSum: BigNumber;
+    numClaimable: number;
+};
+
+export type UnclaimedRowProps = UnclaimedRowInfo & UnclaimedRowActions;
+
+export type UnclaimedPoolTokenRowProps = OverviewPoolToken &
+    UnclaimedRowActions & {
+        poolAddress: UnclaimedRowProps['poolAddress'];
+        settlementTokenSymbol: string;
+    };

--- a/types/unclaimedTokens.ts
+++ b/types/unclaimedTokens.ts
@@ -2,12 +2,11 @@ import BigNumber from 'bignumber.js';
 import { LogoTicker } from '~/components/General';
 import { OnClickCommit, OverviewAsset, OverviewPoolToken } from './portfolio';
 
-/* Unclaimed tokens */
 export type UnclaimedRowActions = {
     onClickCommitAction: OnClickCommit;
 };
 export type UnclaimedRowInfo = {
-    poolName: string; // pool name
+    poolName: string;
     poolAddress: string;
     marketTicker: LogoTicker;
     claimableLongTokens: OverviewPoolToken;


### PR DESCRIPTION
Add stake button to claimed tokens table
- /stake page handles query string params `stake` and `unstake` the values of these params should be a pool token address. The handler will search for the token address in the farms object and will open the relevant modal if it can find it
- preferences stake > unstake, could handle this in a number of ways but would only be the case if someone is intentionally fucking with it and tries to set both
- can handle multiple query string params values but will only ever take first one, again this is just to not break it if someone is fucking with it
- if it cant find the token in the farms then it wont open the modal 
- re structure some types and move them into /types