### PR TITLE
show correct skew in pools table

### DIFF
--- a/archetypes/Pools/PoolsTable/index.tsx
+++ b/archetypes/Pools/PoolsTable/index.tsx
@@ -352,7 +352,7 @@ const PoolRow: React.FC<
                     <ShortBalance />
                     {showNextRebalance ? (
                         <>
-                            <div>{pool.skew.toFixed(3)}</div>
+                            <div>{pool.nextSkew.toFixed(3)}</div>
                             <div className="mt-1">
                                 <UpOrDownWithTooltip
                                     oldValue={pool.skew}


### PR DESCRIPTION
use `nextSkew` in pools table `next rebalance` view instead of current skew