### PR TITLE
simplify data on portfolio page

### DIFF
--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { CommitActionEnum, SideEnum } from '@tracer-protocol/pools-js';
-import { DeltaEnum } from '~/archetypes/Pools/state';
 import { TableRow } from '~/components/General/TWTable';
 import { PoolStatusBadge, PoolStatusBadgeContainer } from '~/components/PoolStatusBadge';
 import Actions from '~/components/TokenActions';
 import TooltipSelector, { TooltipKeys } from '~/components/Tooltips/TooltipSelector';
-import UpOrDown from '~/components/UpOrDown';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
 import { ClaimedRowActions, ClaimedTokenRowProps } from '~/types/claimedTokens';
 import { PoolStatus } from '~/types/pools';
@@ -26,7 +24,6 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
     onClickCommitAction,
     onClickStake,
     leveragedNotionalValue,
-    entryPrice,
     poolStatus,
 }) => {
     const poolIsDeprecated = poolStatus === PoolStatus.Deprecated;
@@ -48,18 +45,6 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
                     amount={balance}
                     price={currentTokenPrice}
                     settlementTokenSymbol={settlementTokenSymbol}
-                />
-            </OverviewTableRowCell>
-            <OverviewTableRowCell>
-                <TokensNotional amount={balance} price={entryPrice} settlementTokenSymbol={settlementTokenSymbol} />
-            </OverviewTableRowCell>
-            <OverviewTableRowCell>
-                <UpOrDown
-                    oldValue={balance.times(entryPrice)}
-                    newValue={balance.times(currentTokenPrice)}
-                    deltaDenotation={DeltaEnum.Numeric}
-                    currency={settlementTokenSymbol}
-                    showCurrencyTicker={true}
                 />
             </OverviewTableRowCell>
             <OverviewTableRowCell>

--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokensTable.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokensTable.tsx
@@ -19,8 +19,6 @@ export const ClaimedTokensTable = ({
                         <TableHeaderCell>Token</TableHeaderCell>
                         <TableHeaderCell className="whitespace-nowrap">Status</TableHeaderCell>
                         <TableHeaderCell className="whitespace-nowrap">Value</TableHeaderCell>
-                        <TableHeaderCell className="whitespace-nowrap">Acquisition Cost</TableHeaderCell>
-                        <TableHeaderCell className="whitespace-nowrap">Unrealised PnL</TableHeaderCell>
                         <TableHeaderCell className="whitespace-nowrap">Leveraged Value</TableHeaderCell>
                         <TableHeaderCell>{/* Empty header for buttons column */}</TableHeaderCell>
                     </tr>

--- a/archetypes/Portfolio/TradeOverviewBanner/index.tsx
+++ b/archetypes/Portfolio/TradeOverviewBanner/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { NetworkHintContainer, NetworkHint } from '~/components/NetworkHint';
 import { Heading } from '~/components/PageTable';
 import { PortfolioOverview } from '~/types/portfolio';
-import { toApproxCurrency, toApproxLocaleString } from '~/utils/converters';
+import { toApproxLocaleString } from '~/utils/converters';
 import * as Styles from './styles';
 import { ConnectWalletBanner } from '../ConnectWalletBanner';
 
@@ -18,9 +18,7 @@ export const DENOTATION_FILTER_OPTIONS = [{ key: 'USD', value: 'USD' }];
 export const TIME_FILTER_OPTIONS = [{ key: 'All Time', value: 'All Time' }];
 
 export const TradeOverviewBanner: React.FC<BannerTypes> = ({ title, account, portfolioOverview, handleConnect }) => {
-    const { portfolioDelta, realisedProfit, totalPortfolioValue, unrealisedProfit } = portfolioOverview;
-
-    const deltaClassName = portfolioDelta > 0 ? 'up' : portfolioDelta < 0 ? 'down' : undefined;
+    const { totalPortfolioValue } = portfolioOverview;
 
     return (
         <>
@@ -34,49 +32,14 @@ export const TradeOverviewBanner: React.FC<BannerTypes> = ({ title, account, por
                 <Styles.Banner className={!!account ? '' : 'empty-state'}>
                     <Styles.Header>
                         <Styles.Subtitle>Valuation</Styles.Subtitle>
-                        <Styles.Actions>
-                            <Styles.Dropdown
-                                value={DENOTATION_FILTER_OPTIONS[0].value}
-                                options={DENOTATION_FILTER_OPTIONS}
-                                onSelect={() => console.log('add logic')}
-                            />
-                            <Styles.Dropdown
-                                value={TIME_FILTER_OPTIONS[0].value}
-                                options={TIME_FILTER_OPTIONS}
-                                onSelect={() => console.log('add logic')}
-                            />
-                        </Styles.Actions>
                     </Styles.Header>
                     <Styles.BannerContent>
                         <Styles.Value>
                             <Styles.Currency>{toApproxLocaleString(totalPortfolioValue)}</Styles.Currency>
                         </Styles.Value>
-                        {account && portfolioDelta !== 0 && (
-                            <Styles.Value className={deltaClassName}>
-                                {portfolioDelta.toFixed(2)}%
-                                <Styles.ArrowIcon large className={deltaClassName} />
-                            </Styles.Value>
-                        )}
                     </Styles.BannerContent>
                 </Styles.Banner>
 
-                <Styles.CardContainer>
-                    <Styles.Card
-                        className={`${unrealisedProfit.gt(0) ? 'up' : unrealisedProfit.lt(0) ? 'down' : ''} arrow`}
-                    >
-                        <div>
-                            <Styles.CardTitle>Unrealised Profit and Loss</Styles.CardTitle>
-                            <Styles.CardValue>{toApproxCurrency(unrealisedProfit)}</Styles.CardValue>
-                        </div>
-                        {!unrealisedProfit.eq(0) && (
-                            <Styles.ArrowIcon className={unrealisedProfit.lt(0) ? 'down' : ''} />
-                        )}
-                    </Styles.Card>
-                    <Styles.Card className={realisedProfit.gt(0) ? 'up' : ''}>
-                        <Styles.CardTitle>Realised Profit and Loss</Styles.CardTitle>
-                        <Styles.CardValue>{toApproxCurrency(realisedProfit)}</Styles.CardValue>
-                    </Styles.Card>
-                </Styles.CardContainer>
                 {!account && handleConnect && <ConnectWalletBanner handleConnect={handleConnect} />}
             </Styles.Container>
         </>

--- a/archetypes/Portfolio/TradeOverviewBanner/styles.tsx
+++ b/archetypes/Portfolio/TradeOverviewBanner/styles.tsx
@@ -23,14 +23,6 @@ export const Banner = styled.div`
     display: flex;
     flex-direction: column;
     width: 100%;
-
-    @media ${({ theme }) => theme.device.xl} {
-        width: 75%;
-
-        &.empty-state {
-            width: 50%;
-        }
-    }
 `;
 
 export const BannerContent = styled.div`

--- a/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensRows.tsx
+++ b/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensRows.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { CommitActionEnum, SideEnum } from '@tracer-protocol/pools-js';
-import { DeltaEnum } from '~/archetypes/Pools/state';
 import { TableRow } from '~/components/General/TWTable';
 import { PoolStatusBadge, PoolStatusBadgeContainer } from '~/components/PoolStatusBadge';
 import Actions from '~/components/TokenActions';
 import TooltipSelector, { TooltipKeys } from '~/components/Tooltips/TooltipSelector';
-import UpOrDown from '~/components/UpOrDown';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
 import { PoolStatus } from '~/types/pools';
 import { OverviewAsset } from '~/types/portfolio';
@@ -17,7 +15,6 @@ import { TokensNotional } from '../Tokens';
 export const UnclaimedPoolTokenRow = ({
     balance,
     leveragedNotionalValue,
-    entryPrice,
     currentTokenPrice,
     onClickCommitAction,
     symbol,
@@ -46,20 +43,6 @@ export const UnclaimedPoolTokenRow = ({
                     price={currentTokenPrice}
                     settlementTokenSymbol={settlementTokenSymbol}
                 />
-            </OverviewTableRowCell>
-            <OverviewTableRowCell>
-                <TokensNotional amount={balance} price={entryPrice} settlementTokenSymbol={settlementTokenSymbol} />
-            </OverviewTableRowCell>
-            <OverviewTableRowCell>
-                <div>
-                    <UpOrDown
-                        oldValue={balance.times(entryPrice)}
-                        newValue={balance.times(currentTokenPrice)}
-                        deltaDenotation={DeltaEnum.Numeric}
-                        currency={settlementTokenSymbol}
-                        showCurrencyTicker={true}
-                    />
-                </div>
             </OverviewTableRowCell>
             <OverviewTableRowCell>
                 <div>{`${leveragedNotionalValue.toFixed(3)} ${settlementTokenSymbol}`}</div>

--- a/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensTable.tsx
+++ b/archetypes/Portfolio/UnclaimedTokens/UnclaimedTokensTable.tsx
@@ -24,8 +24,6 @@ export const UnclaimedTokensTable = ({
                         <TableHeaderCell>Token</TableHeaderCell>
                         <TableHeaderCell className="whitespace-nowrap">Status</TableHeaderCell>
                         <TableHeaderCell className="whitespace-nowrap">Token Valuation</TableHeaderCell>
-                        <TableHeaderCell className="whitespace-nowrap">Acquisition Cost</TableHeaderCell>
-                        <TableHeaderCell className="whitespace-nowrap">Unrealised PnL</TableHeaderCell>
                         <TableHeaderCell className="whitespace-nowrap">Notional Value</TableHeaderCell>
                         <TableHeaderCell>{/* Empty header for buttons column */}</TableHeaderCell>
                     </tr>

--- a/hooks/usePortfolioOverview/index.tsx
+++ b/hooks/usePortfolioOverview/index.tsx
@@ -54,6 +54,9 @@ export const usePortfolioOverview = (): PortfolioOverview => {
                     .plus(userBalances.aggregateBalances.settlementTokens)
                     .plus(pendingAmounts.longMint)
                     .plus(pendingAmounts.shortMint)
+                    // not accurate but not sure how much it matters
+                    .plus(calcNotionalValue(nextLongTokenPrice, pendingAmounts.longBurn))
+                    .plus(calcNotionalValue(nextShortTokenPrice, pendingAmounts.shortBurn))
                     .plus(totalStaked);
             });
 

--- a/hooks/usePortfolioOverview/usePortfolioOverview.test.ts
+++ b/hooks/usePortfolioOverview/usePortfolioOverview.test.ts
@@ -109,9 +109,6 @@ describe('usePortfolioOverview hook', () => {
     it('usePortfolioOverview runs correctly', () => {
         const { result } = renderHook(() => usePortfolioOverview());
         expect(result.current.totalPortfolioValue.toNumber()).toBe(0);
-        expect(result.current.unrealisedProfit.toNumber()).toBe(0);
-        expect(result.current.realisedProfit.toNumber()).toBe(0);
-        expect(result.current.portfolioDelta).toBe(0);
     });
 
     it('caclulates filled state', () => {
@@ -122,9 +119,6 @@ describe('usePortfolioOverview hook', () => {
         // token prices are $1 for the first case
         // totalPortfolioValue summation of aggregateBalances (200), walletBalances (25), and pendingCommits (50)
         expect(result.current.totalPortfolioValue.toNumber()).toBe(225);
-        expect(result.current.unrealisedProfit.toNumber()).toBe(0);
-        expect(result.current.realisedProfit.toNumber()).toBe(25);
-        expect(result.current.portfolioDelta).toBe(0);
 
         // long token increase
         (usePools as jest.Mock).mockReturnValue(LONG_TOKEN_PRICE_INCREASE);
@@ -132,9 +126,6 @@ describe('usePortfolioOverview hook', () => {
 
         // all long tokens value increase by 10%
         expect(result.current.totalPortfolioValue.toNumber()).toBe(236.5);
-        expect(result.current.unrealisedProfit.toNumber()).toBe(11.5);
-        expect(result.current.realisedProfit.toNumber()).toBe(25);
-        expect(result.current.portfolioDelta).toBe(5.111111111111112);
 
         expect(selectAccount as jest.Mock).toHaveBeenCalledTimes(1);
     }),
@@ -166,9 +157,6 @@ describe('usePortfolioOverview hook', () => {
             const { result } = renderHook(() => usePortfolioOverview());
 
             expect(result.current.totalPortfolioValue.toNumber()).toBe(225);
-            expect(result.current.unrealisedProfit.toNumber()).toBe(0);
-            expect(result.current.realisedProfit.toNumber()).toBe(25);
-            expect(result.current.portfolioDelta).toBe(0);
         });
     it('handles fully staked', () => {
         const stakedLongTokens = 10;
@@ -199,9 +187,6 @@ describe('usePortfolioOverview hook', () => {
         const { result } = renderHook(() => usePortfolioOverview());
 
         expect(result.current.totalPortfolioValue.toNumber()).toBe(225);
-        expect(result.current.unrealisedProfit.toNumber()).toBe(0);
-        expect(result.current.realisedProfit.toNumber()).toBe(25);
-        expect(result.current.portfolioDelta).toBe(0);
     });
     it('handles over staked with 0 balances', () => {
         // staking more tokens than have minted (have received from another wallet);
@@ -214,9 +199,6 @@ describe('usePortfolioOverview hook', () => {
         const { result } = renderHook(() => usePortfolioOverview());
 
         expect(result.current.totalPortfolioValue.toNumber()).toBe(300);
-        expect(result.current.unrealisedProfit.toNumber()).toBe(300);
-        expect(result.current.realisedProfit.toNumber()).toBe(0);
-        expect(result.current.portfolioDelta).toBe(0);
     });
     it('handles mints', () => {
         const mintAmounts = {
@@ -239,9 +221,6 @@ describe('usePortfolioOverview hook', () => {
         // should only increase totalPortfolioValue
         // price delta will decrease slightly since the portfolio increase and dilution of profit/loss
         expect(result.current.totalPortfolioValue.toNumber()).toBe(271.5);
-        expect(result.current.unrealisedProfit.toNumber()).toBe(11.5);
-        expect(result.current.realisedProfit.toNumber()).toBe(25);
-        expect(result.current.portfolioDelta).toBe(4.423076923076923);
     }),
         it('handles burns', () => {
             // with burns we also have to reduce from either wallet balance or aggregate balances other wise we are
@@ -286,9 +265,6 @@ describe('usePortfolioOverview hook', () => {
 
             // portfolio value should remain the same
             expect(result.current.totalPortfolioValue.toNumber()).toBe(236.5);
-            expect(result.current.unrealisedProfit.toNumber()).toBe(11.5);
-            expect(result.current.realisedProfit.toNumber()).toBe(25);
-            expect(result.current.portfolioDelta).toBe(5.111111111111112);
         });
     it('handles disconnected account', () => {
         (selectAccount as jest.Mock).mockReturnValue(undefined);
@@ -296,8 +272,5 @@ describe('usePortfolioOverview hook', () => {
 
         // portfolio value should remain the same
         expect(result.current.totalPortfolioValue.toNumber()).toBe(0);
-        expect(result.current.unrealisedProfit.toNumber()).toBe(0);
-        expect(result.current.realisedProfit.toNumber()).toBe(0);
-        expect(result.current.portfolioDelta).toBe(0);
     });
 });

--- a/types/portfolio.ts
+++ b/types/portfolio.ts
@@ -4,9 +4,6 @@ import { TokenType } from '~/archetypes/Portfolio/state';
 
 export type PortfolioOverview = {
     totalPortfolioValue: BigNumber;
-    unrealisedProfit: BigNumber;
-    realisedProfit: BigNumber;
-    portfolioDelta: number; //percentage change
 };
 
 export type OnClickStake = (token: string, action: 'stake' | 'unstake') => void;


### PR DESCRIPTION
remove portolio page datapoints that rely on tracking user commit/trade pricing (PnL, acquisition cost, etc)