### PR TITLE
Pool 21 portfolio sell button tooltips

### DIFF
--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
@@ -3,12 +3,7 @@ import { CommitActionEnum, SideEnum, NETWORKS } from '@tracer-protocol/pools-js'
 import { TableRow } from '~/components/General/TWTable';
 import { PoolStatusBadge, PoolStatusBadgeContainer } from '~/components/PoolStatusBadge';
 import Actions from '~/components/TokenActions';
-import {
-    PortfolioBurnTooltip,
-    PortfolioFlipTooltip,
-    PortfolioSellTooltip,
-    PortfolioStakeTooltip,
-} from '~/components/Tooltips';
+import { PortfolioBurnTooltip, PortfolioSellTooltip, PortfolioStakeTooltip } from '~/components/Tooltips';
 import TooltipSelector, { TooltipKeys } from '~/components/Tooltips/TooltipSelector';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
 import { ClaimedRowActions, ClaimedTokenRowProps } from '~/types/claimedTokens';

--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
@@ -75,7 +75,6 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
                         Sell
                     </ActionsButton>
                 </PortfolioSellTooltip>
-                {console.log(expectedExecution)}
                 <StyledTooltip
                     title={
                         <>

--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
@@ -68,7 +68,7 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
                         size="xs"
                         variant="primary-light"
                         disabled={!balance.toNumber()}
-                        onClick={() => open(constructBalancerLink(address, NETWORKS.ARBITRUM, true), '_blank')}
+                        onClick={() => open(constructBalancerLink(address, NETWORKS.ARBITRUM, false), '_blank')}
                     >
                         Sell
                     </ActionsButton>

--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { CommitActionEnum, SideEnum, NETWORKS } from '@tracer-protocol/pools-js';
 import { TableRow } from '~/components/General/TWTable';
 import { PoolStatusBadge, PoolStatusBadgeContainer } from '~/components/PoolStatusBadge';
+import TimeLeft from '~/components/TimeLeft';
 import Actions from '~/components/TokenActions';
-import { PortfolioBurnTooltip, PortfolioSellTooltip, PortfolioStakeTooltip } from '~/components/Tooltips';
+import { PortfolioSellTooltip, PortfolioStakeTooltip, StyledTooltip } from '~/components/Tooltips';
 import TooltipSelector, { TooltipKeys } from '~/components/Tooltips/TooltipSelector';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
 import { ClaimedRowActions, ClaimedTokenRowProps } from '~/types/claimedTokens';
@@ -26,6 +27,7 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
     onClickCommitAction,
     onClickStake,
     leveragedNotionalValue,
+    expectedExecution,
     poolStatus,
 }) => {
     const poolIsDeprecated = poolStatus === PoolStatus.Deprecated;
@@ -73,7 +75,14 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
                         Sell
                     </ActionsButton>
                 </PortfolioSellTooltip>
-                <PortfolioBurnTooltip>
+                {console.log(expectedExecution)}
+                <StyledTooltip
+                    title={
+                        <>
+                            Burn the Pool Token on Tracer and receive it in <TimeLeft targetTime={expectedExecution} />.
+                        </>
+                    }
+                >
                     <ActionsButton
                         size="xs"
                         variant="primary-light"
@@ -82,7 +91,7 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
                     >
                         Burn
                     </ActionsButton>
-                </PortfolioBurnTooltip>
+                </StyledTooltip>
                 <TooltipSelector
                     tooltip={{
                         key: poolIsDeprecated ? TooltipKeys.DeprecatedPoolFlipCommit : TooltipKeys.PortfolioFlip,

--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
-import { CommitActionEnum, SideEnum } from '@tracer-protocol/pools-js';
+import { CommitActionEnum, SideEnum, NETWORKS } from '@tracer-protocol/pools-js';
 import { TableRow } from '~/components/General/TWTable';
 import { PoolStatusBadge, PoolStatusBadgeContainer } from '~/components/PoolStatusBadge';
 import Actions from '~/components/TokenActions';
+import {
+    PortfolioBurnTooltip,
+    PortfolioFlipTooltip,
+    PortfolioSellTooltip,
+    PortfolioStakeTooltip,
+} from '~/components/Tooltips';
 import TooltipSelector, { TooltipKeys } from '~/components/Tooltips/TooltipSelector';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
 import { ClaimedRowActions, ClaimedTokenRowProps } from '~/types/claimedTokens';
 import { PoolStatus } from '~/types/pools';
+import { constructBalancerLink } from '~/utils/balancer';
 import { Market } from '../Market';
 import { ActionsButton, ActionsCell } from '../OverviewTable/styles';
 import { OverviewTableRowCell } from '../OverviewTable/styles';
@@ -23,7 +30,6 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
     currentTokenPrice,
     onClickCommitAction,
     onClickStake,
-    onClickSell,
     leveragedNotionalValue,
     poolStatus,
 }) => {
@@ -52,34 +58,39 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
                 <div>{`${leveragedNotionalValue.toFixed(3)} ${settlementTokenSymbol}`}</div>
             </OverviewTableRowCell>
             <ActionsCell>
-                <ActionsButton
-                    size="xs"
-                    variant="primary-light"
-                    // will never be disabled if it gets included as a row it will always be either to stake or to unstake
-                    onClick={() => onClickStake(address, shouldStake ? 'stake' : 'unstake')}
-                >
-                    {shouldStake ? 'Stake' : 'Unstake'}
-                </ActionsButton>
-                <ActionsButton
-                    size="xs"
-                    variant="primary-light"
-                    disabled={!balance.toNumber()}
-                    onClick={() => onClickSell(address, shouldStake ? 'stake' : 'unstake')}
-                >
-                    Sell
-                    {address}
-                </ActionsButton>
-                <ActionsButton
-                    size="xs"
-                    variant="primary-light"
-                    disabled={!balance.toNumber()}
-                    onClick={() => onClickCommitAction(poolAddress, side, CommitActionEnum.burn)}
-                >
-                    Burn
-                </ActionsButton>
+                <PortfolioStakeTooltip>
+                    <ActionsButton
+                        size="xs"
+                        variant="primary-light"
+                        // will never be disabled if it gets included as a row it will always be either to stake or to unstake
+                        onClick={() => onClickStake(address, shouldStake ? 'stake' : 'unstake')}
+                    >
+                        {shouldStake ? 'Stake' : 'Unstake'}
+                    </ActionsButton>
+                </PortfolioStakeTooltip>
+                <PortfolioSellTooltip>
+                    <ActionsButton
+                        size="xs"
+                        variant="primary-light"
+                        disabled={!balance.toNumber()}
+                        onClick={() => open(constructBalancerLink(address, NETWORKS.ARBITRUM, true), '_blank')}
+                    >
+                        Sell
+                    </ActionsButton>
+                </PortfolioSellTooltip>
+                <PortfolioBurnTooltip>
+                    <ActionsButton
+                        size="xs"
+                        variant="primary-light"
+                        disabled={!balance.toNumber()}
+                        onClick={() => onClickCommitAction(poolAddress, side, CommitActionEnum.burn)}
+                    >
+                        Burn
+                    </ActionsButton>
+                </PortfolioBurnTooltip>
                 <TooltipSelector
                     tooltip={{
-                        key: poolIsDeprecated ? TooltipKeys.DeprecatedPoolFlipCommit : undefined,
+                        key: poolIsDeprecated ? TooltipKeys.DeprecatedPoolFlipCommit : TooltipKeys.PortfolioFlip,
                     }}
                 >
                     <div>

--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
@@ -23,6 +23,7 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
     currentTokenPrice,
     onClickCommitAction,
     onClickStake,
+    onClickSell,
     leveragedNotionalValue,
     poolStatus,
 }) => {
@@ -58,6 +59,15 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
                     onClick={() => onClickStake(address, shouldStake ? 'stake' : 'unstake')}
                 >
                     {shouldStake ? 'Stake' : 'Unstake'}
+                </ActionsButton>
+                <ActionsButton
+                    size="xs"
+                    variant="primary-light"
+                    disabled={!balance.toNumber()}
+                    onClick={() => onClickSell(address, shouldStake ? 'stake' : 'unstake')}
+                >
+                    Sell
+                    {address}
                 </ActionsButton>
                 <ActionsButton
                     size="xs"

--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokensTable.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokensTable.tsx
@@ -31,6 +31,7 @@ export const ClaimedTokensTable = ({
                             <ClaimedTokenRow
                                 {...token}
                                 key={token.address}
+                                tokenAddress={token.address}
                                 poolStatus={token.poolStatus}
                                 onClickCommitAction={onClickCommitAction}
                                 onClickStake={onClickStake}

--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokensTable.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokensTable.tsx
@@ -31,7 +31,6 @@ export const ClaimedTokensTable = ({
                             <ClaimedTokenRow
                                 {...token}
                                 key={token.address}
-                                tokenAddress={token.address}
                                 poolStatus={token.poolStatus}
                                 onClickCommitAction={onClickCommitAction}
                                 onClickStake={onClickStake}

--- a/components/Tooltips/TooltipSelector/index.tsx
+++ b/components/Tooltips/TooltipSelector/index.tsx
@@ -6,6 +6,7 @@ import {
     PowerLeverageTip,
     DeprecatedPoolMintCommitTooltip,
     DeprecatedPoolFlipCommitTooltip,
+    PortfolioFlipTooltip,
 } from '../';
 
 export enum TooltipKeys {
@@ -14,6 +15,7 @@ export enum TooltipKeys {
     PowerLeverage = 'power-leverage',
     DeprecatedPoolMintCommit = 'deprecated-pool-mint-commit',
     DeprecatedPoolFlipCommit = 'deprecated-pool-flip-commit',
+    PortfolioFlip = 'portfolio-flip',
 }
 
 export type TooltipSelectorProps = {
@@ -37,6 +39,9 @@ const TooltipSelector: React.FC<{ tooltip: TooltipSelectorProps }> = ({ tooltip,
 
         case TooltipKeys.DeprecatedPoolFlipCommit:
             return <DeprecatedPoolFlipCommitTooltip>{children}</DeprecatedPoolFlipCommitTooltip>;
+
+        case TooltipKeys.PortfolioFlip:
+            return <PortfolioFlipTooltip>{children}</PortfolioFlipTooltip>;
 
         default:
             return <StyledTooltip title={tooltip.content}>{children}</StyledTooltip>;

--- a/components/Tooltips/index.tsx
+++ b/components/Tooltips/index.tsx
@@ -96,11 +96,6 @@ export const PortfolioSellTooltip: React.FC = ({ children }) => {
     return <StyledTooltip title={Content}>{children}</StyledTooltip>;
 };
 
-export const PortfolioBurnTooltip: React.FC = ({ children }) => {
-    const Content = 'Burn the Pool Token on Tracer and receive it in {time}.';
-    return <StyledTooltip title={Content}>{children}</StyledTooltip>;
-};
-
 export const PortfolioFlipTooltip: React.FC = ({ children }) => {
     const Content = 'Flip the Pool Token to take an opposite view in the market.';
     return <StyledTooltip title={Content}>{children}</StyledTooltip>;

--- a/components/Tooltips/index.tsx
+++ b/components/Tooltips/index.tsx
@@ -85,3 +85,23 @@ export const DeprecatedPoolFlipCommitTooltip: React.FC = ({ children }) => {
 
     return <StyledTooltip title={Content}>{children}</StyledTooltip>;
 };
+
+export const PortfolioStakeTooltip: React.FC = ({ children }) => {
+    const Content = 'Stake the Pool Token to earn liquidity mining rewards!';
+    return <StyledTooltip title={Content}>{children}</StyledTooltip>;
+};
+
+export const PortfolioSellTooltip: React.FC = ({ children }) => {
+    const Content = 'Sell the Pool Token instantly using Balancer.';
+    return <StyledTooltip title={Content}>{children}</StyledTooltip>;
+};
+
+export const PortfolioBurnTooltip: React.FC = ({ children }) => {
+    const Content = 'Burn the Pool Token on Tracer and receive it in {time}.';
+    return <StyledTooltip title={Content}>{children}</StyledTooltip>;
+};
+
+export const PortfolioFlipTooltip: React.FC = ({ children }) => {
+    const Content = 'Flip the Pool Token to take an opposite view in the market.';
+    return <StyledTooltip title={Content}>{children}</StyledTooltip>;
+};

--- a/hooks/useUserClaimedTokens/index.tsx
+++ b/hooks/useUserClaimedTokens/index.tsx
@@ -10,7 +10,6 @@ export const useUserClaimedTokens = (): LoadingRows<ClaimedTokenRowProps> => {
     const { pools, isLoadingPools } = usePools();
     const farmBalances = useFarmBalances();
     const [rows, setRows] = useState<ClaimedTokenRowProps[]>([]);
-
     useEffect(() => {
         if (pools) {
             const poolValues = Object.values(pools);
@@ -47,6 +46,7 @@ export const useUserClaimedTokens = (): LoadingRows<ClaimedTokenRowProps> => {
                         entryPrice: userBalances.tradeStats.avgShortEntryPriceWallet,
                         settlementTokenSymbol: poolInstance.settlementToken.symbol,
                         stakedTokens: shortStaked,
+                        expectedExecution: pools[address].upkeepInfo.expectedExecution,
                         poolStatus,
                     });
                 }
@@ -66,6 +66,7 @@ export const useUserClaimedTokens = (): LoadingRows<ClaimedTokenRowProps> => {
                         entryPrice: userBalances.tradeStats.avgLongEntryPriceWallet,
                         settlementTokenSymbol: poolInstance.settlementToken.symbol,
                         stakedTokens: longStaked,
+                        expectedExecution: pools[address].upkeepInfo.expectedExecution,
                         poolStatus,
                     });
                 }

--- a/types/claimedTokens.ts
+++ b/types/claimedTokens.ts
@@ -15,4 +15,5 @@ export type ClaimedTokenRowProps = Omit<OverviewPoolToken, 'type'> & {
     effectiveGain: number;
     stakedTokens: BigNumber;
     poolStatus: PoolStatus;
+    expectedExecution: number;
 };


### PR DESCRIPTION
- Sell button added to Portfolio page token rows
- Add tooltips to Stake, Sell, Burn and Flip action buttons