### PR TITLE
redirect from v1 portfolio sub pages to single v2 portfolio page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,13 +14,28 @@ module.exports = {
 
     async redirects() {
         return [
-            { "source": "/bridge", "destination": "https://bridge.arbitrum.io/", permanent: true },
-            { "source": "/pools", "destination": "/", permanent: true },
-            { "source": "/stakebpt", "destination": "/stake" , permanent: true },
-            { "source": "/privacy-policy", "destination": "https://tracer.finance/privacy-policy", permanent: true },
-            { "source": "/terms-of-use", "destination": "https://tracer.finance/privacy-policy#terms-of-use", permanent: true },
-            { "source": "/disclaimer", "destination": "https://tracer.finance/privacy-policy#interfaces-disclaimer", permanent: true }
-        ]
+            { source: '/bridge', destination: 'https://bridge.arbitrum.io/', permanent: true },
+            { source: '/pools', destination: '/', permanent: true },
+            { source: '/stakebpt', destination: '/stake', permanent: true },
+            { source: '/privacy-policy', destination: 'https://tracer.finance/privacy-policy', permanent: true },
+            {
+                source: '/terms-of-use',
+                destination: 'https://tracer.finance/privacy-policy#terms-of-use',
+                permanent: true,
+            },
+            {
+                source: '/disclaimer',
+                destination: 'https://tracer.finance/privacy-policy#interfaces-disclaimer',
+                permanent: true,
+            },
+            { source: '/portfolio/history', destination: '/portfolio', permanent: true },
+            { source: '/portfolio/commits', destination: '/portfolio', permanent: true },
+            {
+                source: '/disclaimer',
+                destination: 'https://tracer.finance/privacy-policy#interfaces-disclaimer',
+                permanent: true,
+            },
+        ];
     },
 
     webpack(config) {


### PR DESCRIPTION
redirect `/portfolio/history` and `portfolio/commits` to `/portfolio` so that toggling from v1 to v2 on these pages does not result in a 404