### PR TITLE
Use pool instances loading

### DIFF
--- a/constants/seo.ts
+++ b/constants/seo.ts
@@ -14,4 +14,4 @@ export const seoContent = {
         description: 'Stake your Pool Tokens to earn TCR rewards.',
         image: '/img/opengraph/stake.jpg',
     },
-}
+};

--- a/hooks/useUpdatePoolInstances/index.ts
+++ b/hooks/useUpdatePoolInstances/index.ts
@@ -15,11 +15,12 @@ import { KnownPoolsInitialisationErrors } from '~/store/PoolInstancesSlice/types
 import { selectWeb3Info } from '~/store/Web3Slice';
 
 import { V2_SUPPORTED_NETWORKS } from '~/types/networks';
+import { randomIntInRange } from '~/utils/helpers';
 import { isSupportedNetwork } from '~/utils/supportedNetworks';
 import { fetchPendingCommits } from '~/utils/tracerAPI';
 import { useAllPoolLists } from '../useAllPoolLists';
 
-const MAX_RETRY_COUNT = 5;
+const MAX_RETRY_COUNT = 10;
 
 /**
  * Wrapper to update all pools information
@@ -87,7 +88,9 @@ export const useUpdatePoolInstances = (): void => {
                                         address: pool.address,
                                         provider,
                                     }),
-                                interval: 500, // half a second between retries
+                                // add randomness to retry delay
+                                // so two failing at the same time are unlikely to be retried at the exact same time
+                                interval: randomIntInRange(300, 1000),
                                 retryCheck: async () => {
                                     retryCount += 1;
 

--- a/hooks/useUpdatePoolInstances/index.ts
+++ b/hooks/useUpdatePoolInstances/index.ts
@@ -70,7 +70,7 @@ export const useUpdatePoolInstances = (): void => {
             // all is good
             const fetchAndSetPools = async () => {
                 setIsFetchingPools(true);
-                console.debug(`Initialising pools ${network.slice()}`, poolLists);
+                console.debug(`Initialising pools ${network.slice()}: ${retryCount}`, poolLists);
                 resetPools();
                 hasSetPools.current = false;
                 setPoolsInitialized(false);

--- a/store/PoolInstancesSlice/index.tsx
+++ b/store/PoolInstancesSlice/index.tsx
@@ -19,7 +19,7 @@ export const createPoolsInstancesSlice: StateSlice<IPoolsInstancesSlice> = (set,
     poolsInitializationError: undefined,
 
     setPool: (pool, network) => {
-        const now = Date.now() / 1000;
+        const now = Math.floor(Date.now() / 1000);
         const expectedExecution = getExpectedExecutionTimestamp(
             pool.frontRunningInterval.toNumber(),
             pool.updateInterval.toNumber(),
@@ -42,7 +42,7 @@ export const createPoolsInstancesSlice: StateSlice<IPoolsInstancesSlice> = (set,
         });
     },
     setMultiplePools: (pools, network) => {
-        const now = Date.now() / 1000;
+        const now = Math.floor(Date.now() / 1000);
         set((state) => {
             pools.forEach((pool) => {
                 const expectedExecution = getExpectedExecutionTimestamp(

--- a/store/PoolInstancesSlice/types.ts
+++ b/store/PoolInstancesSlice/types.ts
@@ -7,6 +7,7 @@ export enum KnownPoolsInitialisationErrors {
     ProviderNotReady = 'Provider not ready',
     NetworkNotSupported = 'Network not supported',
     NoPools = 'No pools found',
+    ExceededMaxRetryCount = 'Exceeded max retry count',
 }
 
 export interface IPoolsInstancesSlice {

--- a/store/main.ts
+++ b/store/main.ts
@@ -14,7 +14,7 @@ import { createPoolsInstancesSlice } from './PoolInstancesSlice';
 import { IPoolsInstancesSlice } from './PoolInstancesSlice/types';
 import { createPoolsSlice } from './PoolsSlice';
 import { IPoolsSlice } from './PoolsSlice/types';
-import {onNetworkChange, onAccountChange} from './subscriptions';
+import { onNetworkChange, onAccountChange } from './subscriptions';
 import { createThemeSlice } from './ThemeSlice';
 import { IThemeSlice } from './ThemeSlice/types';
 import { createTransactionSlice } from './TransactionSlice';
@@ -76,11 +76,5 @@ export const useStore = create<
     ),
 );
 
-
 export const networkSub = useStore.subscribe((state) => state.web3Slice.network, onNetworkChange);
 export const accountSub = useStore.subscribe((state) => state.web3Slice.account, onAccountChange);
-
-
-
-
-

--- a/store/subscriptions.ts
+++ b/store/subscriptions.ts
@@ -1,14 +1,14 @@
-import { useStore } from ".";
-import {StoreNetwork, StoreAccount} from "./types";
+import { StoreNetwork, StoreAccount } from './types';
+import { useStore } from '.';
 
 export const onNetworkChange = (network: StoreNetwork, oldNetwork: StoreNetwork): void => {
-    console.debug(`Store network changed from ${oldNetwork} to ${network}`)
+    console.debug(`Store network changed from ${oldNetwork} to ${network}`);
     if (network) {
-        useStore.getState().poolsSlice.fetchPoolLists(network)
+        useStore.getState().poolsSlice.fetchPoolLists(network);
     }
-}
+};
 
 export const onAccountChange = (account: StoreAccount, oldAccount: StoreAccount): void => {
-    console.debug(`Store account changed from ${oldAccount} to ${account}`)
+    console.debug(`Store account changed from ${oldAccount} to ${account}`);
     useStore.getState().ensSlice.checkENSName(account);
-}
+};

--- a/types/claimedTokens.ts
+++ b/types/claimedTokens.ts
@@ -9,7 +9,7 @@ export type ClaimedRowActions = {
 };
 
 export type ClaimedTokenRowProps = Omit<OverviewPoolToken, 'type'> & {
-    network?: KnownNetwork | undefined,
+    network?: KnownNetwork | undefined;
     name: string;
     poolAddress: string;
     settlementTokenSymbol: string;

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -12,3 +12,7 @@ export const BNFromString = (str: string, decimals: number): BigNumber => {
 export const escapeRegExp = (text: string): string => {
     return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 };
+
+export const randomIntInRange = (min: number, max: number): number => {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+};

--- a/utils/poolLists.ts
+++ b/utils/poolLists.ts
@@ -37,7 +37,7 @@ const uris = (network: KnownNetwork): PoolListUris => {
 const get = async (uri: string): Promise<PoolList | undefined> => {
     try {
         const [protocol] = uri.split('://');
-        console.log("Fetching pools from", uri);
+        console.log('Fetching pools from', uri);
         if (protocol === 'https') {
             const data = await fetch(uri).then((res) => res.json());
             return data;


### PR DESCRIPTION
Alchemy just suggests to retry. It gives a number of ways this should be handled. 
https://docs.alchemy.com/alchemy/documentation/throughput#retries

For this implementation if it fails it just retries initiating the pools 5 times before giving up. From my tests it seems to do the job but we should check with a lot of different users

Try to replicate it by looking for this error
<img width="552" alt="Screen Shot 2022-06-17 at 9 37 05 am" src="https://user-images.githubusercontent.com/29347276/174195242-7cff1f16-edca-4b10-bda1-7b94763406b0.png">

I've found it happens mostly when going from another site to pools site with an already connected wallet and custom rpc
