### PR TITLE
ensure correct token address is used when adding tokens to wallet

### DIFF
--- a/archetypes/Pools/PoolsTable/index.tsx
+++ b/archetypes/Pools/PoolsTable/index.tsx
@@ -694,7 +694,7 @@ const TokenRows: React.FC<
                         </Button>
                         <Actions
                             token={{
-                                address: poolAddress,
+                                address: tokenInfo.address,
                                 decimals: decimals,
                                 symbol: tokenInfo.symbol,
                             }}


### PR DESCRIPTION
- currently the pool address is being used when importing tokens into metamask
- update so that the token address is being correctly passed when importing tokens