### PR TITLE
update pool status badges to oracle details badges

### DIFF
--- a/archetypes/Pools/PoolsTable/index.tsx
+++ b/archetypes/Pools/PoolsTable/index.tsx
@@ -8,7 +8,7 @@ import { CommitActionEnum, NETWORKS, SideEnum } from '@tracer-protocol/pools-js'
 import { Logo, LogoTicker, tokenSymbolToLogoTicker } from '~/components/General';
 import Button from '~/components/General/Button';
 import { Table, TableHeader, TableRow, TableHeaderCell, TableRowCell } from '~/components/General/TWTable';
-import { PoolStatusBadge, PoolStatusBadgeContainer } from '~/components/PoolStatusBadge';
+import { OracleDetailsBadge, OracleDetailsBadgeContainer } from '~/components/OracleDetailsBadge';
 import TimeLeft from '~/components/TimeLeft';
 import Actions from '~/components/TokenActions';
 import { StyledTooltip } from '~/components/Tooltips';
@@ -347,10 +347,10 @@ const PoolRow: React.FC<
                 {/** Pool rows */}
                 <TableRowCell rowSpan={2}>
                     <div className="mb-1 flex font-bold">
-                        <PoolStatusBadgeContainer>
+                        <OracleDetailsBadgeContainer>
                             <div className="mr-2 text-lg">{pool.leverage}</div>
-                            <PoolStatusBadge status={pool.poolStatus} />
-                        </PoolStatusBadgeContainer>
+                            <OracleDetailsBadge oracleDetails={pool.oracleDetails} />
+                        </OracleDetailsBadgeContainer>
                     </div>
                     <div className="flex items-center">
                         {pool.collateralAsset}

--- a/archetypes/Pools/state.ts
+++ b/archetypes/Pools/state.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { Upkeep } from '~/hooks/useUpkeeps';
 import { MarketFilterEnum, LeverageFilterEnum, CollateralFilterEnum, SortByEnum } from '~/types/filters';
-import { PoolStatus } from '~/types/pools';
+import { OracleDetails, PoolStatus } from '~/types/pools';
 
 export enum DeltaEnum {
     Percentile = 0,
@@ -64,6 +64,7 @@ export interface BrowseTableRowData {
     collateralAssetAddress: string;
 
     poolStatus: PoolStatus;
+    oracleDetails: OracleDetails;
     estimatedSkew: number;
 }
 

--- a/components/OracleDetailsBadge/index.tsx
+++ b/components/OracleDetailsBadge/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled from 'styled-components';
+import { OracleDetails } from '~/types/pools';
+import { formatSeconds } from '~/utils/converters';
+
+export const OracleDetailsBadgeContainer = styled.div`
+    position: relative;
+    width: fit-content;
+    display: flex;
+`;
+
+const StyledBadge = styled.div`
+    background: #3535dc;
+    color: #fff;
+    font-size: 13px;
+    padding: 0.25rem 0.5rem;
+    top: 0;
+    line-height: 150%;
+    border-radius: 3px;
+    font-weight: 700;
+    background: #1c64f2;
+    color: #fff;
+    border-color: #1c64f2;
+`;
+
+export const OracleDetailsBadge = ({ oracleDetails }: { oracleDetails: OracleDetails }): JSX.Element => {
+    switch (oracleDetails.type) {
+        case 'SMA':
+            return (
+                <StyledBadge>
+                    {oracleDetails.updateInterval * oracleDetails.numPeriods
+                        ? formatSeconds(oracleDetails.updateInterval * oracleDetails.numPeriods)
+                        : ''}{' '}
+                    SMA
+                </StyledBadge>
+            );
+        case 'Spot':
+        default:
+            return <StyledBadge>Spot Price</StyledBadge>;
+    }
+};

--- a/constants/pools.ts
+++ b/constants/pools.ts
@@ -89,6 +89,11 @@ export const DEFAULT_POOLSTATE: PoolInfo = {
         expectedFrontRunningShortTokenPrice: new BigNumber(0),
         expectedFrontRunningOraclePrice: new BigNumber(0),
     },
+    oracleDetails: {
+        type: 'SMA',
+        updateInterval: 0,
+        numPeriods: 0,
+    },
 };
 
 export interface PoolListMap {

--- a/hooks/useBrowsePools/index.tsx
+++ b/hooks/useBrowsePools/index.tsx
@@ -39,6 +39,7 @@ export const useBrowsePools = (): LoadingRows<BrowseTableRowData> => {
             poolValues.forEach((pool_) => {
                 const {
                     poolInstance: pool,
+                    oracleDetails,
                     poolStatus,
                     userBalances,
                     upkeepInfo,
@@ -147,6 +148,7 @@ export const useBrowsePools = (): LoadingRows<BrowseTableRowData> => {
                     committer: committer.address,
                     collateralAsset: settlementToken.symbol,
                     collateralAssetAddress: settlementToken.address,
+                    oracleDetails,
                     poolStatus,
                 });
             });

--- a/hooks/useUpdatePoolInstances/index.ts
+++ b/hooks/useUpdatePoolInstances/index.ts
@@ -36,6 +36,7 @@ export const useUpdatePoolInstances = (): void => {
         updatePoolCommitStats,
         updatePoolBalancerPrices,
         updateNextPoolStates,
+        updateOracleDetails,
     } = useStore(selectPoolInstanceUpdateActions, shallow);
     const { addMutlipleCommits } = useStore(selectUserCommitActions, shallow);
     const { provider, account, network } = useStore(selectWeb3Info, shallow);
@@ -209,6 +210,7 @@ export const useUpdatePoolInstances = (): void => {
             updatePoolCommitStats(pools_, network);
             updateNextPoolStates(pools_, network);
             updatePoolBalancerPrices(pools_, network);
+            updateOracleDetails(pools_);
         }
     }, [network, poolsInitialized]);
 };

--- a/store/PoolInstancesSlice/index.tsx
+++ b/store/PoolInstancesSlice/index.tsx
@@ -1,5 +1,6 @@
 import { ethers } from 'ethers';
 import BigNumber from 'bignumber.js';
+import { SMAOracle__factory } from '@tracer-protocol/perpetual-pools-contracts/types';
 import { getExpectedExecutionTimestamp } from '@tracer-protocol/pools-js';
 import { balancerConfig } from '~/constants/balancer';
 import { deprecatedPools } from '~/constants/deprecatedPools';
@@ -38,6 +39,7 @@ export const createPoolsInstancesSlice: StateSlice<IPoolsInstancesSlice> = (set,
                 poolCommitStats: DEFAULT_POOLSTATE.poolCommitStats,
                 balancerPrices: DEFAULT_POOLSTATE.balancerPrices,
                 nextPoolState: DEFAULT_POOLSTATE.nextPoolState,
+                oracleDetails: DEFAULT_POOLSTATE.oracleDetails,
             };
         });
     },
@@ -62,6 +64,7 @@ export const createPoolsInstancesSlice: StateSlice<IPoolsInstancesSlice> = (set,
                     poolCommitStats: DEFAULT_POOLSTATE.poolCommitStats,
                     balancerPrices: DEFAULT_POOLSTATE.balancerPrices,
                     nextPoolState: DEFAULT_POOLSTATE.nextPoolState,
+                    oracleDetails: DEFAULT_POOLSTATE.oracleDetails,
                 };
             });
         });
@@ -95,6 +98,14 @@ export const createPoolsInstancesSlice: StateSlice<IPoolsInstancesSlice> = (set,
             state.pools[pool].userBalances.shortToken.approvedAmount = approvals.shortTokenAmount;
             state.pools[pool].userBalances.longToken.approvedAmount = approvals.longTokenAmount;
             state.pools[pool].userBalances.settlementToken.approvedAmount = approvals.settlementTokenAmount;
+        });
+    },
+    setOracleDetails: (pool, oracleDetails) => {
+        if (!get().pools[pool]) {
+            return;
+        }
+        set((state) => {
+            state.pools[pool].oracleDetails = oracleDetails;
         });
     },
     setAggregateBalances: (pool, aggregateBalances) => {
@@ -375,6 +386,48 @@ export const createPoolsInstancesSlice: StateSlice<IPoolsInstancesSlice> = (set,
                 });
         });
     },
+    updateOracleDetails(pools_) {
+        pools_.forEach((pool_) => {
+            const pool = get().pools[pool_];
+
+            if (!pool || !pool.poolInstance._contract) {
+                return;
+            }
+
+            pool.poolInstance._contract
+                .oracleWrapper()
+                .then((oracleAddress) => {
+                    if (!pool.poolInstance.provider) {
+                        throw new Error('cannot get oracle details, pool instance provider not available');
+                    }
+                    const oracle = SMAOracle__factory.connect(oracleAddress, pool.poolInstance.provider);
+                    return Promise.all([oracle.numPeriods(), oracle.updateInterval()]);
+                })
+                .then(([numPeriods, updateInterval]) => {
+                    set((state) => {
+                        if (state.pools[pool_]) {
+                            state.pools[pool_].oracleDetails = {
+                                type: 'SMA',
+                                numPeriods: numPeriods.toNumber(),
+                                updateInterval: updateInterval.toNumber(),
+                            };
+                        }
+                    });
+                })
+                .catch(() => {
+                    // if error reading sma parameters, assume its a spot oracle
+                    set((state) => {
+                        if (state.pools[pool_]) {
+                            state.pools[pool_].oracleDetails = {
+                                type: 'Spot',
+                                numPeriods: 0,
+                                updateInterval: 0,
+                            };
+                        }
+                    });
+                });
+        });
+    },
     simulateUpdateAvgEntryPrices: (pool_) => {
         set((state) => {
             const pool = state.pools[pool_];
@@ -442,6 +495,7 @@ export const selectPoolInstanceUpdateActions: (state: StoreState) => {
     updatePoolTokenBalances: IPoolsInstancesSlice['updatePoolTokenBalances'];
     updateSettlementTokenBalances: IPoolsInstancesSlice['updateSettlementTokenBalances'];
     updateTokenApprovals: IPoolsInstancesSlice['updateTokenApprovals'];
+    updateOracleDetails: IPoolsInstancesSlice['updateOracleDetails'];
     updateTradeStats: IPoolsInstancesSlice['updateTradeStats'];
     updateNextPoolStates: IPoolsInstancesSlice['updateNextPoolStates'];
     updatePoolCommitStats: IPoolsInstancesSlice['updatePoolCommitStats'];
@@ -453,6 +507,7 @@ export const selectPoolInstanceUpdateActions: (state: StoreState) => {
     updatePoolTokenBalances: state.poolsInstancesSlice.updatePoolTokenBalances,
     updateSettlementTokenBalances: state.poolsInstancesSlice.updateSettlementTokenBalances,
     updateTokenApprovals: state.poolsInstancesSlice.updateTokenApprovals,
+    updateOracleDetails: state.poolsInstancesSlice.updateOracleDetails,
     updateTradeStats: state.poolsInstancesSlice.updateTradeStats,
     updateNextPoolStates: state.poolsInstancesSlice.updateNextPoolStates,
     updatePoolCommitStats: state.poolsInstancesSlice.updatePoolCommitStats,

--- a/store/PoolInstancesSlice/types.ts
+++ b/store/PoolInstancesSlice/types.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import BigNumber from 'bignumber.js';
 import { Pool, KnownNetwork } from '@tracer-protocol/pools-js';
-import { AggregateBalances, TradeStats, PoolInfo, PoolCommitStats, NextPoolState } from '~/types/pools';
+import { AggregateBalances, TradeStats, PoolInfo, PoolCommitStats, NextPoolState, OracleDetails } from '~/types/pools';
 
 export enum KnownPoolsInitialisationErrors {
     ProviderNotReady = 'Provider not ready',
@@ -37,6 +37,7 @@ export interface IPoolsInstancesSlice {
     setPoolIsWaiting: (pool: string, isWaitingForUpkeep: boolean) => void;
     setPoolExpectedExecution: (pool: string) => void;
     setTokenApproved: (pool: string, token: 'settlementToken' | 'shortToken' | 'longToken', value: BigNumber) => void;
+    setOracleDetails: (pool: string, oracleDetails: OracleDetails) => void;
 
     handlePoolUpkeep: (
         pool: string,
@@ -62,6 +63,7 @@ export interface IPoolsInstancesSlice {
         provider: ethers.providers.JsonRpcProvider | undefined,
         account: string | undefined,
     ) => void;
+    updateOracleDetails: (pools: string[]) => void;
     updatePoolBalances: (pool: string, provider: ethers.providers.JsonRpcProvider | undefined) => void;
     updatePoolBalancerPrices: (pool: string[], network: KnownNetwork | undefined) => void;
     simulateUpdateAvgEntryPrices: (pool: string) => void;

--- a/types/pools.ts
+++ b/types/pools.ts
@@ -68,6 +68,12 @@ type TokenBalance = {
     balance: BigNumber;
 };
 
+export type OracleDetails = {
+    type: 'SMA' | 'Spot';
+    numPeriods: number;
+    updateInterval: number;
+};
+
 export type TradeStats = {
     avgLongEntryPriceWallet: BigNumber;
     avgShortEntryPriceWallet: BigNumber;
@@ -142,6 +148,7 @@ export type PoolInfo = {
         // settlementToken: BigNumber; // in some stable coin of our choosing
     };
     nextPoolState: NextPoolState;
+    oracleDetails: OracleDetails;
 };
 
 export type TradeStatsAPIResponse = {

--- a/utils/converters.ts
+++ b/utils/converters.ts
@@ -133,6 +133,32 @@ export const timeAgo: (current: number, previous: number) => string = (current, 
  *
  * @param time as timestamp value in seconds
  */
+export const extractTimeSegments: (time: number) => {
+    d: number;
+    h: number;
+    m: number;
+    s: number;
+} = (time) => {
+    if (time > 0) {
+        return {
+            d: Math.floor(time / (60 * 60 * 24)),
+            h: Math.floor((time / (60 * 60)) % 24),
+            m: Math.floor((time / 60) % 60),
+            s: Math.floor(time % 60),
+        };
+    }
+    return {
+        d: 0,
+        h: 0,
+        m: 0,
+        s: 0,
+    };
+};
+
+/**
+ *
+ * @param time as timestamp value in seconds
+ */
 export const timeTill: (time: number) => {
     d?: number;
     h?: number;
@@ -140,17 +166,13 @@ export const timeTill: (time: number) => {
     s: number;
 } = (time) => {
     const difference = time - Date.now() / 1000;
-    if (difference > 0) {
-        return {
-            d: Math.floor(difference / (60 * 60 * 24)),
-            h: Math.floor((difference / (60 * 60)) % 24),
-            m: Math.floor((difference / 60) % 60),
-            s: Math.floor(difference % 60),
-        };
-    }
-    return {
-        s: 0,
-    };
+    return extractTimeSegments(difference);
+};
+
+export const formatSeconds: (seconds: number) => string = (seconds) => {
+    const { d, h, m, s } = extractTimeSegments(seconds);
+
+    return `${d ? `${d}d` : ''} ${h ? `${h}h` : ''} ${m ? `${m}m` : ''}  ${s ? `${s}s` : ''}`;
 };
 
 /**


### PR DESCRIPTION
https://tracerfinance.atlassian.net/browse/PML-173

- add oracle details to pool store (this will be re-used in simplified buy page for pool summary)
- display oracle details in pools table instead of pool status

![image](https://user-images.githubusercontent.com/14157626/175860847-4b81c6d4-3341-45e6-b18d-eeb7066a42f1.png)
