### PR TITLE
add farms for 12 hour btc markets, support farms for imported pools

### DIFF
--- a/constants/staking.ts
+++ b/constants/staking.ts
@@ -105,29 +105,52 @@ export const farmConfig: Record<KnownNetwork, FarmConfig> = {
                 pool: '0xa740b84Fd3547b9C445844c30A10Cde6dce3E08B',
                 abi: StakingRewards__factory.abi,
             },
+            {
+                address: '0x6d52d4C087DD8a167eCA0008fb4c69D99169DcE8', // 3-BTC/USD+USDC-12h Balancer LP
+                pool: '0x2bfb8aeE6EB2dcCd694f8eCB4C31FdeBfC22b55a',
+                abi: StakingRewards__factory.abi,
+                isBPTFarm: true,
+                balancerPoolId: '0xc999678122cbf8a30cb72c53d4bdd72abd96af880001000000000000000000b4',
+                link: 'https://arbitrum.balancer.fi/#/pool/0xc999678122cbf8a30cb72c53d4bdd72abd96af880001000000000000000000b4',
+                name: '3-BTC/USD+USDC-12h',
+            },
+            {
+                address: '0x3004CC46432522B0AeA30d16aF769B1727aA0c26', // 3L-BTC/USD+USDC-12h
+                pool: '0x2bfb8aeE6EB2dcCd694f8eCB4C31FdeBfC22b55a',
+                abi: StakingRewards__factory.abi,
+            },
+            {
+                address: '0x0896Fd59b574f536751c82B8Dd9fd9466af009aC', // 3S-BTC/USD+USDC-12h
+                pool: '0x2bfb8aeE6EB2dcCd694f8eCB4C31FdeBfC22b55a',
+                abi: StakingRewards__factory.abi,
+            },
             // deprecated
             {
                 address: '0xcD8c0662cf72512857e98646b5C8363782c137A7', // 3-BTC/USD-long-farm
                 pool: '0x6D3Fb4AA7ddCa8CBc88F7BA94B36ba83fF6bA234',
                 abi: StakingRewards__factory.abi,
+                name: '3L-BTC/USD+USDC',
                 rewardsEnded: true,
             },
             {
                 address: '0x046B21659C445f43f2c621c874F79868dC6FA159', // 3-BTC/USDC-short-farm
                 pool: '0x6D3Fb4AA7ddCa8CBc88F7BA94B36ba83fF6bA234',
                 abi: StakingRewards__factory.abi,
+                name: '3S-BTC/USD+USDC',
                 rewardsEnded: true,
             },
             {
                 address: '0xC21159bF0252A37b0c281DF2D9B723120cAa86c7', // 3-ETH/USDC-long-farm
                 pool: '0x3C16b9efE5E4Fc0ec3963F17c64a3dcBF7269207',
                 abi: StakingRewards__factory.abi,
+                name: '3L-ETH/USD+USDC',
                 rewardsEnded: true,
             },
             {
                 address: '0x224949832f3dbf9a365D9bA3ec504727a103E96E', // 3-ETH/USDC-short-farm
                 pool: '0x3C16b9efE5E4Fc0ec3963F17c64a3dcBF7269207',
                 abi: StakingRewards__factory.abi,
+                name: '3S-ETH/USD+USDC',
                 rewardsEnded: true,
             },
         ],

--- a/types/staking/index.ts
+++ b/types/staking/index.ts
@@ -44,6 +44,7 @@ type FarmInfo = {
     linkText?: string;
     rewardsEnded?: boolean;
     isBPTFarm?: boolean;
+    name?: string; // so that farms belonging to imported pools have names
 };
 
 export type FarmConfig = {


### PR DESCRIPTION
- add farms for 12hr BTC pool tokens + balancer LP tokens
- improve support for farms relating to pools that have been imported/are no longer DAO verified