### PR TITLE
Add cursor: not-allowed to input and Max elements for Stake modal 

### DIFF
--- a/archetypes/Stake/StakeModal/index.tsx
+++ b/archetypes/Stake/StakeModal/index.tsx
@@ -99,6 +99,7 @@ const StakeModal: React.FC<StakeModalProps> = ({ state, dispatch, onStake, onApp
                             />
                             <Max
                                 className="m-auto"
+                                disabled={!isApproved}
                                 onClick={(_e) =>
                                     dispatch({
                                         type: 'setAmount',
@@ -125,7 +126,9 @@ const StakeModal: React.FC<StakeModalProps> = ({ state, dispatch, onStake, onApp
                         )}
                     </div>
                 ) : (
-                    <>{state.stakeModalState !== 'claim' ? 'Token approval required to stake' : ''}</>
+                    <div className="mt-2 text-red-500">
+                        {state.stakeModalState !== 'claim' ? 'Token approval required to stake' : ''}
+                    </div>
                 )}
                 {isApproved ? (
                     <Button

--- a/components/General/Input/Numeric/index.tsx
+++ b/components/General/Input/Numeric/index.tsx
@@ -22,6 +22,7 @@ export const Input = React.memo(
         className = defaultClassName,
         characterBlacklist = defaultCharacterBlacklist,
         pattern = defaultPattern,
+        disabled,
         ...rest
     }: {
         value: string | number;
@@ -30,6 +31,7 @@ export const Input = React.memo(
         fontSize?: string;
         align?: 'right' | 'left';
         characterBlacklist?: Record<string, boolean>;
+        disabled?: boolean;
     } & Omit<React.HTMLProps<HTMLInputElement>, 'ref' | 'onChange' | 'as'>) => {
         const onKeyPress = useCallback(
             (e: any) => {
@@ -44,6 +46,7 @@ export const Input = React.memo(
         return (
             <input
                 {...rest}
+                disabled={disabled}
                 value={value}
                 onChange={(event) => {
                     const { value } = event.target;
@@ -71,6 +74,7 @@ export const Input = React.memo(
                 spellCheck="false"
                 className={classNames(
                     'outline-none placeholder-low-emphesis focus:placeholder-primary relative flex-auto overflow-hidden overflow-ellipsis border-none focus:border',
+                    disabled ? 'cursor-not-allowed' : 'cursor-text',
                     className,
                 )}
             />

--- a/components/General/Max/index.tsx
+++ b/components/General/Max/index.tsx
@@ -1,15 +1,17 @@
 import styled from 'styled-components';
 import { Theme } from '~/store/ThemeSlice/themes';
 
-const Max = styled.div`
-    cursor: pointer;
+const Max = styled.div<{ disabled?: boolean }>`
     text-transform: uppercase;
     font-weight: bold;
     font-size: 16px;
     line-height: 150%;
     color: ${({ theme }) => (theme.theme === Theme.Light ? '#2A2AC7' : '#fff')};
+    cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+    opacity: ${({ disabled }) => (disabled ? '0.8' : '1')};
+
     &:hover {
-        text-decoration: underline;
+        text-decoration: ${({ disabled }) => (disabled ? 'none' : 'underline')};
     }
 `;
 


### PR DESCRIPTION
- Make approval text red to highlight importance

Before (normal cursor on input, Max button allows interaction, black requires approval text):
![image](https://user-images.githubusercontent.com/19278287/177682741-8129114d-f126-4633-bfaa-09c868028c4a.png)

After (cursor not-allowed on input, Max button disabled interaction, red requires approval text):
![image](https://user-images.githubusercontent.com/19278287/177682914-46a6bc44-719d-4df9-943b-735caa05863a.png)
