### PR TITLE
Add Mint Summary modal to Buy page

### DIFF
--- a/archetypes/BuyTokens/ExchangeButtons.tsx
+++ b/archetypes/BuyTokens/ExchangeButtons.tsx
@@ -27,7 +27,7 @@ export type EXButtonsProps = {
     market: string;
     poolTokens: BrowseTableRowData[];
     isInvalid: boolean;
-    handleOpenModal: () => void;
+    onButtonClick: () => void;
 } & ExchangeButtonProps;
 
 export const ExchangeButtons: React.FC<EXButtonsProps> = ({
@@ -43,7 +43,7 @@ export const ExchangeButtons: React.FC<EXButtonsProps> = ({
     swapState,
     account,
     userBalances,
-    handleOpenModal,
+    onButtonClick,
 }) => {
     const { selectedPool } = swapState;
     // Required for tracking trade actions
@@ -105,7 +105,7 @@ export const ExchangeButtons: React.FC<EXButtonsProps> = ({
                     <MintButtonContainer isValidAmount={isValidAmount} account={account}>
                         {userBalances.settlementToken.approvedAmount?.gte(userBalances.settlementToken.balance) ||
                         !userBalances.settlementToken.approvedAmount.eq(0) ? (
-                            <TracerMintButton onClick={handleOpenModal} disabled={!isValidAmount}>
+                            <TracerMintButton onClick={onButtonClick} disabled={!isValidAmount}>
                                 <span className="mr-2 inline-block">Mint on</span>
                                 <TracerSVG className="w-[90px]" alt="Tracer logo" />
                             </TracerMintButton>

--- a/archetypes/BuyTokens/MintButton.tsx
+++ b/archetypes/BuyTokens/MintButton.tsx
@@ -1,11 +1,9 @@
 import React, { useMemo } from 'react';
 import BigNumber from 'bignumber.js';
-import { CommitActionEnum, PoolToken, SideEnum } from '@tracer-protocol/pools-js';
+import { PoolToken, SideEnum } from '@tracer-protocol/pools-js';
 import { TracerMintButton } from '~/archetypes/BuyTokens/ExchangeButtons';
-import Button from '~/components/General/Button';
-import { ExchangeButtonProps } from '~/components/General/Button/ExchangeButton';
-import TracerSVG from '~/public/img/logos/tracer/tracer_logo.svg';
 import { calcNumTokens } from '~/archetypes/Exchange/Summary/utils';
+import { ExchangeButtonProps } from '~/components/General/Button/ExchangeButton';
 
 export enum MintSourceEnum {
     tracer = 'Tracer',
@@ -25,13 +23,13 @@ type MintButtonProps = {
         balance: BigNumber,
         source: MintSourceEnum,
     ) => void;
+    handleCloseModal: () => void;
 } & ExchangeButtonProps;
 
 const MintButton: React.FC<MintButtonProps> = ({
     swapState,
     swapDispatch,
     userBalances,
-    approve,
     pool,
     amountBN,
     commit,
@@ -39,67 +37,45 @@ const MintButton: React.FC<MintButtonProps> = ({
     token,
     isLong,
     trackBuyAction,
+    handleCloseModal,
 }) => {
-    const { selectedPool, side, leverage, invalidAmount, commitAction, balanceType } = swapState;
+    const { selectedPool, side, leverage, invalidAmount, balanceType } = swapState;
     const nextTokenPrice = useMemo(
         () => (isLong ? pool.getNextLongTokenPrice() : pool.getNextShortTokenPrice()),
         [isLong, pool.longToken, pool.shortToken],
     );
-
     const expectedAmount = calcNumTokens(amountBN, nextTokenPrice);
 
-    if (
-        (!userBalances.settlementToken.approvedAmount?.gte(userBalances.settlementToken.balance) ||
-            userBalances.settlementToken.approvedAmount.eq(0)) &&
-        commitAction !== CommitActionEnum.burn
-    ) {
-        return (
-            <Button
-                size="lg"
-                variant="primary"
-                disabled={!selectedPool}
-                onClick={(_e) => {
-                    if (!approve) {
-                        return;
-                    }
-                    approve(selectedPool ?? '', pool.settlementToken.symbol);
-                }}
-            >
-                Unlock {pool.settlementToken.symbol}
-            </Button>
-        );
-    } else {
-        return (
-            <TracerMintButton
-                disabled={!selectedPool || amountBN.eq(0) || invalidAmount.isInvalid}
-                onClick={(_e) => {
-                    if (!commit) {
-                        return;
-                    }
+    return (
+        <TracerMintButton
+            disabled={!selectedPool || amountBN.eq(0) || invalidAmount.isInvalid}
+            onClick={(_e) => {
+                if (!commit) {
+                    return;
+                }
 
-                    commit(selectedPool ?? '', commitType, balanceType, amountBN, {
-                        onSuccess: () => {
-                            swapDispatch?.({ type: 'setAmount', value: '' });
-                        },
-                    });
+                commit(selectedPool ?? '', commitType, balanceType, amountBN, {
+                    onSuccess: () => {
+                        swapDispatch?.({ type: 'setAmount', value: '' });
+                        handleCloseModal();
+                    },
+                });
 
-                    trackBuyAction(
-                        side,
-                        leverage,
-                        token.name,
-                        pool.settlementToken.symbol,
-                        expectedAmount,
-                        amountBN,
-                        userBalances.settlementToken.balance,
-                        MintSourceEnum.tracer,
-                    );
-                }}
-            >
-                <span className="mr-2 inline-block">Mint on</span>
-                <TracerSVG className="w-[90px]" alt="Tracer logo" />
-            </TracerMintButton>
-        );
-    }
+                trackBuyAction(
+                    side,
+                    leverage,
+                    token.name,
+                    pool.settlementToken.symbol,
+                    expectedAmount,
+                    amountBN,
+                    userBalances.settlementToken.balance,
+                    MintSourceEnum.tracer,
+                );
+            }}
+        >
+            <span className="mr-2 inline-block">Mint Pool Tokens</span>
+        </TracerMintButton>
+    );
 };
 
 export default MintButton;

--- a/archetypes/BuyTokens/MintButton.tsx
+++ b/archetypes/BuyTokens/MintButton.tsx
@@ -26,7 +26,7 @@ type MintButtonProps = {
         poolBalanceShort: BigNumber,
         isPreCommit: boolean,
     ) => void;
-    handleCloseModal: () => void;
+    handleModalClose: () => void;
 } & ExchangeButtonProps;
 
 const MintButton: React.FC<MintButtonProps> = ({
@@ -40,7 +40,7 @@ const MintButton: React.FC<MintButtonProps> = ({
     token,
     isLong,
     trackBuyAction,
-    handleCloseModal,
+    handleModalClose,
 }) => {
     const { selectedPool, side, leverage, invalidAmount, balanceType } = swapState;
     const nextTokenPrice = useMemo(
@@ -60,7 +60,7 @@ const MintButton: React.FC<MintButtonProps> = ({
                 commit(selectedPool ?? '', commitType, balanceType, amountBN, {
                     onSuccess: () => {
                         swapDispatch?.({ type: 'setAmount', value: '' });
-                        handleCloseModal();
+                        handleModalClose();
                         trackBuyAction(
                             side,
                             leverage,

--- a/archetypes/BuyTokens/MintSummaryModal.tsx
+++ b/archetypes/BuyTokens/MintSummaryModal.tsx
@@ -41,7 +41,7 @@ type MSModalProps = {
     };
     token: PoolToken;
     isLong: boolean;
-    handleCloseModal: () => void;
+    onClose: () => void;
     isSummaryOpen: boolean;
 };
 
@@ -56,7 +56,7 @@ const MintSummaryModal: React.FC<MSModalProps> = ({
     userBalances,
     token,
     isLong,
-    handleCloseModal,
+    onClose,
     isSummaryOpen,
 }) => {
     const { commit, approve } = usePoolInstanceActions();
@@ -93,8 +93,8 @@ const MintSummaryModal: React.FC<MSModalProps> = ({
     }, [selectedPool, commitType, amountBN, ethPrice, gasPrice]);
 
     return (
-        <TWModal open={isSummaryOpen} onClose={handleCloseModal}>
-            <Close onClick={handleCloseModal} className="close" />
+        <TWModal open={isSummaryOpen} onClose={onClose}>
+            <Close onClick={onClose} className="close" />
             <Title>Mint Summary</Title>
             <Summary
                 pool={pool}

--- a/archetypes/BuyTokens/MintSummaryModal.tsx
+++ b/archetypes/BuyTokens/MintSummaryModal.tsx
@@ -118,7 +118,7 @@ const MintSummaryModal: React.FC<MSModalProps> = ({
                 token={token}
                 isLong={isLong}
                 trackBuyAction={trackBuyAction}
-                handleCloseModal={handleCloseModal}
+                handleModalClose={onClose}
             />
         </TWModal>
     );

--- a/archetypes/BuyTokens/MintSummaryModal.tsx
+++ b/archetypes/BuyTokens/MintSummaryModal.tsx
@@ -1,0 +1,154 @@
+import React, { useContext, useMemo, useState } from 'react';
+import BigNumber from 'bignumber.js';
+import styled from 'styled-components';
+import { CommitActionEnum, CommitEnum, PoolToken, SideEnum } from '@tracer-protocol/pools-js';
+import MintButton from '~/archetypes/BuyTokens/MintButton';
+import Summary from '~/archetypes/Exchange/Summary';
+import { TWModal } from '~/components/General/TWModal';
+import { CommitActionSideMap } from '~/constants/commits';
+import { AnalyticsContext } from '~/context/AnalyticsContext';
+import { useBigNumber, SwapState } from '~/context/SwapContext';
+import useBalancerETHPrice from '~/hooks/useBalancerETHPrice';
+import useExpectedCommitExecution from '~/hooks/useExpectedCommitExecution';
+import { useGasPrice } from '~/hooks/useGasPrice';
+import { usePool } from '~/hooks/usePool';
+import { usePoolInstanceActions } from '~/hooks/usePoolInstanceActions';
+import CloseIcon from '~/public/img/general/close.svg';
+import { AggregateBalances, TokenBalance, TradeStats } from '~/types/pools';
+import { formatBN } from '~/utils/converters';
+
+const DEFAULT_GAS_FEE = new BigNumber(0);
+
+type MSModalProps = {
+    isOpen: boolean;
+    amount: string;
+    selectedPool: string | undefined;
+    side: SideEnum;
+    commitAction: CommitActionEnum;
+    commitType: CommitEnum;
+    invalidAmount: {
+        message?: string | undefined;
+        isInvalid: boolean;
+    };
+    swapState: SwapState;
+    swapDispatch: any;
+    userBalances: {
+        shortToken: TokenBalance;
+        longToken: TokenBalance;
+        settlementToken: TokenBalance;
+        aggregateBalances: AggregateBalances;
+        tradeStats: TradeStats;
+    };
+    token: PoolToken;
+    isLong: boolean;
+    handleCloseModal: () => void;
+    isSummaryOpen: boolean;
+};
+
+const MintSummaryModal: React.FC<MSModalProps> = ({
+    amount,
+    selectedPool,
+    side,
+    commitAction,
+    invalidAmount,
+    swapState,
+    swapDispatch,
+    userBalances,
+    token,
+    isLong,
+    handleCloseModal,
+    isSummaryOpen,
+}) => {
+    const { commit, approve } = usePoolInstanceActions();
+    const { trackBuyAction } = useContext(AnalyticsContext);
+    const [commitGasFees, setCommitGasFees] = useState<Partial<Record<CommitActionEnum, BigNumber>>>({});
+    const gasPrice = useGasPrice();
+    const ethPrice = useBalancerETHPrice();
+    const { commitGasFee } = usePoolInstanceActions();
+
+    const amountBN = useBigNumber(amount);
+    const commitType = CommitActionSideMap[commitAction][side];
+
+    const { poolInstance: pool } = usePool(selectedPool);
+
+    const receiveIn = useExpectedCommitExecution(pool.lastUpdate, pool.updateInterval, pool.frontRunningInterval);
+
+    useMemo(async () => {
+        if (commitGasFee) {
+            const fee: BigNumber | undefined = await commitGasFee(
+                selectedPool ?? '',
+                commitType,
+                swapState.balanceType,
+                amountBN,
+            ).catch((_err) => undefined);
+            if (fee) {
+                const gasPriceInEth = formatBN(new BigNumber(gasPrice ?? 0), 9);
+                const costInEth = fee.times(gasPriceInEth);
+                setCommitGasFees({
+                    ...commitGasFees,
+                    [commitAction]: ethPrice.times(costInEth),
+                });
+            }
+        }
+    }, [selectedPool, commitType, amountBN, ethPrice, gasPrice]);
+
+    return (
+        <TWModal open={isSummaryOpen} onClose={handleCloseModal}>
+            <Close onClick={handleCloseModal} className="close" />
+            <Title>Mint Summary</Title>
+            <Summary
+                pool={pool}
+                showBreakdown={!invalidAmount.isInvalid}
+                isLong={side === SideEnum.long}
+                amount={amountBN}
+                receiveIn={receiveIn}
+                commitAction={commitAction}
+                gasFee={commitGasFees[commitAction] ?? DEFAULT_GAS_FEE}
+                showTokenImage
+            />
+            <MintButton
+                swapState={swapState}
+                swapDispatch={swapDispatch}
+                userBalances={userBalances}
+                approve={approve}
+                pool={pool}
+                amountBN={amountBN}
+                commit={commit}
+                commitType={commitType}
+                token={token}
+                isLong={isLong}
+                trackBuyAction={trackBuyAction}
+                handleCloseModal={handleCloseModal}
+            />
+        </TWModal>
+    );
+};
+
+export default MintSummaryModal;
+
+const Title = styled.h2`
+    font-weight: 600;
+    font-size: 20px;
+    color: ${({ theme }) => theme.fontColor.primary};
+    margin-bottom: 15px;
+
+    @media (min-width: 640px) {
+        margin-bottom: 20px;
+    }
+`;
+
+const Close = styled(CloseIcon)`
+    position: absolute;
+    right: 1rem;
+    top: 1.5rem;
+    width: 0.75rem;
+    height: 0.75rem;
+    cursor: pointer;
+
+    @media (min-width: 640px) {
+        right: 2.5rem;
+        top: 3rem;
+        width: 1rem;
+        height: 1rem;
+    }
+`;

--- a/archetypes/BuyTokens/index.tsx
+++ b/archetypes/BuyTokens/index.tsx
@@ -1,8 +1,9 @@
-import React, { useContext, useEffect, useMemo } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { BalanceTypeEnum, SideEnum } from '@tracer-protocol/pools-js';
 import ExchangeButtons from '~/archetypes/BuyTokens/ExchangeButtons';
 import { LeverageSelector, MarketDropdown, PoolTypeDropdown, SideSelector } from '~/archetypes/BuyTokens/Inputs';
+import MintSummaryModal from '~/archetypes/BuyTokens/MintSummaryModal';
 import { isInvalidAmount } from '~/archetypes/Exchange/Inputs';
 import AmountInput from '~/archetypes/Exchange/Inputs/AmountInput';
 import { Logo, tokenSymbolToLogoTicker } from '~/components/General';
@@ -21,6 +22,7 @@ import { selectAccount, selectHandleConnect } from '~/store/Web3Slice';
 import { PoolInfo } from '~/types/pools';
 
 const BuyTokens: React.FC = () => {
+    const [isSummaryOpen, setSummaryOpen] = useState(false);
     const { swapState = swapDefaults, swapDispatch = noDispatch } = useContext(SwapContext);
     const { amount, leverage, market, markets, selectedPool, side, commitAction, balanceType, invalidAmount } =
         swapState || {};
@@ -167,83 +169,110 @@ const BuyTokens: React.FC = () => {
         ],
     );
 
+    const handleOpenModal = () => {
+        setSummaryOpen(true);
+    };
+
+    const handleCloseModal = () => {
+        setSummaryOpen(false);
+    };
+
     return (
-        <Container>
-            <FormBackdrop>
-                <Header>
-                    <H1>Get Leveraged Tokens</H1>
-                </Header>
-                <Divider />
-                <Table>
-                    <tbody>
-                        {/* Only show 'token to receive' and arrow row after user selection */}
-                        {/* Only show Market type row for markets that have multiple pools that match user selection */}
-                        {buyTableData.map((v, i) => {
-                            if (
-                                ((v.name === 'Token to receive' || v.name === '') && token && token.symbol) ||
-                                (v.name === 'Market type' &&
-                                    market &&
-                                    markets &&
-                                    leverage &&
-                                    (markets?.[market]?.[leverage] as unknown as PoolInfo[])?.length > 1) ||
-                                (v.name !== 'Token to receive' && v.name !== '' && v.name !== 'Market type')
-                            ) {
-                                return (
-                                    <TableRow key={`${v.name}-${i}`}>
-                                        <TableCellLeft>
-                                            {v.name}{' '}
-                                            {v.TooltipEl && (
-                                                <v.TooltipEl>
-                                                    <StyledInfoIcon />
-                                                </v.TooltipEl>
-                                            )}
-                                        </TableCellLeft>
-                                        <TableCellRight
-                                            noPadding={
-                                                (!!token && v.name === '') ||
-                                                (!!token && !!token.symbol && v.name === 'Token to spend')
-                                            }
-                                        >
-                                            {v.selector}
-                                        </TableCellRight>
-                                    </TableRow>
-                                );
-                            }
-                        })}
-                    </tbody>
-                </Table>
-                {account && poolTokens.length && token && token.symbol ? (
-                    <ExchangeButtons
-                        account={account}
-                        amount={amount}
-                        pool={pool}
-                        token={token}
-                        isLong={isLong}
-                        side={side}
-                        leverage={leverage}
-                        market={market}
-                        poolTokens={poolTokens}
-                        swapState={swapState}
-                        swapDispatch={swapDispatch}
-                        userBalances={userBalances}
-                        amountBN={amountBN}
-                        commitType={commitType}
-                        isInvalid={invalidAmount.isInvalid}
-                    />
-                ) : null}
-                {!account && (
-                    <ConnectButtonStyled
-                        size="lg"
-                        variant="primary"
-                        onClick={(_e) => {
-                            handleConnect();
-                        }}
-                    >
-                        Connect Wallet
-                    </ConnectButtonStyled>
-                )}
-            </FormBackdrop>
-        </Container>
+        <>
+            <Container>
+                <FormBackdrop>
+                    <Header>
+                        <H1>Get Leveraged Tokens</H1>
+                    </Header>
+                    <Divider />
+                    <Table>
+                        <tbody>
+                            {/* Only show 'token to receive' and arrow row after user selection */}
+                            {/* Only show Market type row for markets that have multiple pools that match user selection */}
+                            {buyTableData.map((v, i) => {
+                                if (
+                                    ((v.name === 'Token to receive' || v.name === '') && token && token.symbol) ||
+                                    (v.name === 'Market type' &&
+                                        market &&
+                                        markets &&
+                                        leverage &&
+                                        (markets?.[market]?.[leverage] as unknown as PoolInfo[])?.length > 1) ||
+                                    (v.name !== 'Token to receive' && v.name !== '' && v.name !== 'Market type')
+                                ) {
+                                    return (
+                                        <TableRow key={`${v.name}-${i}`}>
+                                            <TableCellLeft>
+                                                {v.name}{' '}
+                                                {v.TooltipEl && (
+                                                    <v.TooltipEl>
+                                                        <StyledInfoIcon />
+                                                    </v.TooltipEl>
+                                                )}
+                                            </TableCellLeft>
+                                            <TableCellRight
+                                                noPadding={
+                                                    (!!token && v.name === '') ||
+                                                    (!!token && !!token.symbol && v.name === 'Token to spend')
+                                                }
+                                            >
+                                                {v.selector}
+                                            </TableCellRight>
+                                        </TableRow>
+                                    );
+                                }
+                            })}
+                        </tbody>
+                    </Table>
+                    {account && poolTokens.length && token && token.symbol ? (
+                        <ExchangeButtons
+                            account={account}
+                            amount={amount}
+                            pool={pool}
+                            token={token}
+                            isLong={isLong}
+                            side={side}
+                            leverage={leverage}
+                            market={market}
+                            poolTokens={poolTokens}
+                            swapState={swapState}
+                            swapDispatch={swapDispatch}
+                            userBalances={userBalances}
+                            amountBN={amountBN}
+                            commitType={commitType}
+                            isInvalid={invalidAmount.isInvalid}
+                            handleOpenModal={handleOpenModal}
+                        />
+                    ) : null}
+                    {!account && (
+                        <ConnectButtonStyled
+                            size="lg"
+                            variant="primary"
+                            onClick={(_e) => {
+                                handleConnect();
+                            }}
+                        >
+                            Connect Wallet
+                        </ConnectButtonStyled>
+                    )}
+                </FormBackdrop>
+            </Container>
+            <MintSummaryModal
+                isOpen={true}
+                amount={amount}
+                selectedPool={selectedPool}
+                side={side}
+                invalidAmount={invalidAmount}
+                commitType={commitType}
+                commitAction={commitAction}
+                swapState={swapState}
+                swapDispatch={swapDispatch}
+                userBalances={userBalances}
+                token={token}
+                isLong={isLong}
+                handleCloseModal={handleCloseModal}
+                isSummaryOpen={isSummaryOpen}
+            />
+        </>
     );
 };
 

--- a/archetypes/BuyTokens/index.tsx
+++ b/archetypes/BuyTokens/index.tsx
@@ -169,11 +169,11 @@ const BuyTokens: React.FC = () => {
         ],
     );
 
-    const handleOpenModal = () => {
+    const handleModalOpen = () => {
         setSummaryOpen(true);
     };
 
-    const handleCloseModal = () => {
+    const handleModalClose = () => {
         setSummaryOpen(false);
     };
 
@@ -240,7 +240,7 @@ const BuyTokens: React.FC = () => {
                             amountBN={amountBN}
                             commitType={commitType}
                             isInvalid={invalidAmount.isInvalid}
-                            onButtonClick={handleOpenModal}
+                            onButtonClick={handleModalOpen}
                         />
                     ) : null}
                     {!account && (
@@ -269,7 +269,7 @@ const BuyTokens: React.FC = () => {
                 userBalances={userBalances}
                 token={token}
                 isLong={isLong}
-                onClose={handleCloseModal}
+                onClose={handleModalClose}
                 isSummaryOpen={isSummaryOpen}
             />
         </>

--- a/archetypes/BuyTokens/index.tsx
+++ b/archetypes/BuyTokens/index.tsx
@@ -240,7 +240,7 @@ const BuyTokens: React.FC = () => {
                             amountBN={amountBN}
                             commitType={commitType}
                             isInvalid={invalidAmount.isInvalid}
-                            handleOpenModal={handleOpenModal}
+                            onButtonClick={handleOpenModal}
                         />
                     ) : null}
                     {!account && (
@@ -269,7 +269,7 @@ const BuyTokens: React.FC = () => {
                 userBalances={userBalances}
                 token={token}
                 isLong={isLong}
-                handleCloseModal={handleCloseModal}
+                onClose={handleCloseModal}
                 isSummaryOpen={isSummaryOpen}
             />
         </>

--- a/archetypes/Exchange/Summary/index.tsx
+++ b/archetypes/Exchange/Summary/index.tsx
@@ -2,13 +2,14 @@ import React, { useMemo } from 'react';
 import { Transition } from '@headlessui/react';
 import { CommitActionEnum } from '@tracer-protocol/pools-js';
 
+import { Logo, tokenSymbolToLogoTicker } from '~/components/General';
 import BurnSummary from './BurnSummary';
 import FlipSummary from './FlipSummary';
 import MintSummary from './MintSummary';
 import * as Styles from './styles';
 import { SummaryProps } from './types';
 
-export default (({ pool, showBreakdown, amount, isLong, receiveIn, commitAction, gasFee }) => {
+export default (({ pool, showBreakdown, amount, isLong, receiveIn, commitAction, gasFee, showTokenImage }) => {
     const token = useMemo(() => (isLong ? pool.longToken : pool.shortToken), [isLong, pool.longToken, pool.shortToken]);
     const nextTokenPrice = useMemo(
         () => (isLong ? pool.getNextLongTokenPrice() : pool.getNextShortTokenPrice()),
@@ -26,6 +27,12 @@ export default (({ pool, showBreakdown, amount, isLong, receiveIn, commitAction,
                     leaveFrom="opacity-100"
                     leaveTo="opacity-0"
                 >
+                    {showTokenImage && token ? (
+                        <div className="mb-4 flex items-center">
+                            <Logo className="mr-2 inline" size="md" ticker={tokenSymbolToLogoTicker(token?.symbol)} />
+                            <span className="font-bold">{token?.symbol}</span>
+                        </div>
+                    ) : null}
                     {commitAction === CommitActionEnum.mint && (
                         <MintSummary
                             amount={amount}

--- a/archetypes/Exchange/Summary/types.ts
+++ b/archetypes/Exchange/Summary/types.ts
@@ -10,6 +10,7 @@ export type SummaryProps = {
     commitAction: CommitActionEnum;
     receiveIn: number;
     gasFee: BigNumber;
+    showTokenImage?: boolean;
 };
 
 type SharedProps = {

--- a/components/General/TWModal/index.tsx
+++ b/components/General/TWModal/index.tsx
@@ -51,7 +51,7 @@ export const TWModal: React.FC<TWModalProps> = ({ open, onClose, size = 'default
                     >
                         <div
                             className={classNames(
-                                'my-4 inline-block w-full transform overflow-hidden rounded-lg bg-theme-background p-10 text-left align-middle shadow-xl transition-all sm:my-8',
+                                'my-4 inline-block w-full transform overflow-hidden rounded-lg bg-theme-background p-4 text-left align-middle shadow-xl transition-all sm:my-8 sm:p-10',
                                 SIZES[size],
                                 className,
                             )}

--- a/types/pools.ts
+++ b/types/pools.ts
@@ -63,7 +63,7 @@ export interface PoolListUris {
  *
  * Pools store types
  */
-type TokenBalance = {
+export type TokenBalance = {
     approvedAmount: BigNumber;
     balance: BigNumber;
 };


### PR DESCRIPTION
When clicking "Mint on Tracer" button on Buy page (root page /) the following modal will now appear to provide the user with more information on the exact fees involved in the transaction:

Desktop:

![image](https://user-images.githubusercontent.com/19278287/178196534-2c6a622d-b25d-4882-aeb4-d42c20611de2.png)

Mobile:

![image](https://user-images.githubusercontent.com/19278287/178196590-bd51c17b-09fc-49be-854f-5d7c5ca31d21.png)

The modal will close upon successful commit, or if the users clicks the close button.

Designs: 

https://www.figma.com/file/gA9jQ5B6ZwWjGKBhGUFbKo/2.0-3.0-Pools?node-id=3386%3A212732