### PR TITLE
Add "Remove Pool from view" button to imported Pool rows

### DIFF
--- a/archetypes/Pools/AddAltPoolModal/index.tsx
+++ b/archetypes/Pools/AddAltPoolModal/index.tsx
@@ -6,11 +6,11 @@ import { TWModal } from '~/components/General/TWModal';
 import { useStore } from '~/store/main';
 import { selectImportPool, selectImportedPools } from '~/store/PoolsSlice';
 import { selectNetwork } from '~/store/Web3Slice';
+import { saveImportedPoolsToLocalStorage } from '~/utils/pools';
 import { isAddress } from '~/utils/rpcMethods';
 import { messages as pool } from './messages';
 import * as Styles from './styles';
 import { BrowseTableRowData } from '../state';
-import { saveImportedPoolsToLocalStorage } from '~/utils/pools';
 
 export default (({ open, onClose, sortedFilteredTokens }) => {
     const importPool = useStore(selectImportPool);

--- a/archetypes/Pools/AddAltPoolModal/index.tsx
+++ b/archetypes/Pools/AddAltPoolModal/index.tsx
@@ -14,7 +14,7 @@ import { BrowseTableRowData } from '../state';
 
 export default (({ open, onClose, sortedFilteredTokens }) => {
     const importPool = useStore(selectImportPool);
-    const getImported = useStore(selectImportedPools);
+    const importedPools = useStore(selectImportedPools);
     const network = useStore(selectNetwork);
 
     const [userInput, setUserInput] = useState<string>('');
@@ -34,7 +34,7 @@ export default (({ open, onClose, sortedFilteredTokens }) => {
 
     const handleImport = () => {
         const isDuplicatePool = sortedFilteredTokens.some((v: BrowseTableRowData) => v.address === userInput);
-        const isDuplicateImport = getImported.some((v) => v.address === userInput);
+        const isDuplicateImport = importedPools.some((v) => v.address === userInput);
 
         if (isDuplicatePool || isDuplicateImport) {
             setImportMsg(pool.exists);

--- a/archetypes/Pools/PoolsTable/index.tsx
+++ b/archetypes/Pools/PoolsTable/index.tsx
@@ -498,6 +498,7 @@ const PoolRow: React.FC<
                     decimals={pool.decimals}
                     settlementTokenSymbol={pool.settlementTokenSymbol}
                     poolTicker={pool.name}
+                    isImportedPool={isImportedPool}
                 />
             </TableRow>
             <TableRow lined isImported={isImportedPool}>

--- a/archetypes/Pools/PoolsTable/index.tsx
+++ b/archetypes/Pools/PoolsTable/index.tsx
@@ -18,6 +18,7 @@ import Info from '~/public/img/general/info.svg';
 import LinkIcon from '~/public/img/general/link.svg';
 import { useStore } from '~/store/main';
 import { selectMarketSpotPrices } from '~/store/MarketSpotPricesSlice';
+import { selectImportedPools } from '~/store/PoolsSlice';
 import { Theme } from '~/store/ThemeSlice/themes';
 import { selectWeb3Info } from '~/store/Web3Slice';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
@@ -570,6 +571,9 @@ const TokenRows: React.FC<
     pastUpkeepTokenInfo,
     poolTicker,
 }) => {
+    const getImported = useStore(selectImportedPools);
+    const isImportedPool = useMemo(() => getImported.some((v) => v.address === poolAddress), [poolAddress]);
+
     const styles = side === SideEnum.long ? longStyles : shortStyles;
 
     return (
@@ -701,6 +705,7 @@ const TokenRows: React.FC<
                             TRADE
                         </Button>
                         <Actions
+                            poolAddress={poolAddress}
                             token={{
                                 address: tokenInfo.address,
                                 decimals: decimals,
@@ -710,6 +715,7 @@ const TokenRows: React.FC<
                                 type: BlockExplorerAddressType.token,
                                 target: poolAddress,
                             }}
+                            isImported={isImportedPool}
                         />
                     </div>
                 ) : null}

--- a/archetypes/Pools/PoolsTable/index.tsx
+++ b/archetypes/Pools/PoolsTable/index.tsx
@@ -345,9 +345,12 @@ const PoolRow: React.FC<
         onClickShowPoolDetailsModal: (pool: BrowseTableRowData) => void;
     } & TProps
 > = ({ pool, account, onClickMintBurn, showNextRebalance, deltaDenotation, onClickShowPoolDetailsModal }) => {
+    const importedPools = useStore(selectImportedPools);
+    const isImportedPool = useMemo(() => importedPools.some((v) => v.address === pool.address), [pool]);
+
     return (
         <>
-            <TableRow lined>
+            <TableRow lined isImported={isImportedPool}>
                 {/** Pool rows */}
                 <TableRowCell rowSpan={2}>
                     <div className="mb-1 flex font-bold">
@@ -497,7 +500,7 @@ const PoolRow: React.FC<
                     poolTicker={pool.name}
                 />
             </TableRow>
-            <TableRow lined>
+            <TableRow lined isImported={isImportedPool}>
                 <TokenRows
                     side={SideEnum.short}
                     onClickMintBurn={onClickMintBurn}
@@ -518,6 +521,7 @@ const PoolRow: React.FC<
                     decimals={pool.decimals}
                     settlementTokenSymbol={pool.settlementTokenSymbol}
                     poolTicker={pool.name}
+                    isImportedPool={isImportedPool}
                 />
             </TableRow>
         </>
@@ -555,6 +559,7 @@ const TokenRows: React.FC<
             tokenBalance: number;
         };
         poolTicker: string;
+        isImportedPool: boolean;
     } & TProps
 > = ({
     side,
@@ -570,10 +575,8 @@ const TokenRows: React.FC<
     antecedentUpkeepTokenInfo,
     pastUpkeepTokenInfo,
     poolTicker,
+    isImportedPool,
 }) => {
-    const importedPools = useStore(selectImportedPools);
-    const isImportedPool = useMemo(() => importedPools.some((v) => v.address === poolAddress), [poolAddress]);
-
     const styles = side === SideEnum.long ? longStyles : shortStyles;
 
     return (

--- a/archetypes/Pools/PoolsTable/index.tsx
+++ b/archetypes/Pools/PoolsTable/index.tsx
@@ -6,7 +6,14 @@ import { CommitActionEnum, NETWORKS, SideEnum } from '@tracer-protocol/pools-js'
 
 import { Logo, LogoTicker, tokenSymbolToLogoTicker } from '~/components/General';
 import Button from '~/components/General/Button';
-import { Table, TableHeader, TableRow, TableHeaderCell, TableRowCell } from '~/components/General/TWTable';
+import {
+    Table,
+    TableHeader,
+    TableRow,
+    TableHeaderCell,
+    TableRowCell,
+    ImportedIndicator,
+} from '~/components/General/TWTable';
 import { OracleDetailsBadge, OracleDetailsBadgeContainer } from '~/components/OracleDetailsBadge';
 import TimeLeft from '~/components/TimeLeft';
 import Actions from '~/components/TokenActions';
@@ -353,6 +360,7 @@ const PoolRow: React.FC<
             <TableRow lined isImported={isImportedPool}>
                 {/** Pool rows */}
                 <TableRowCell rowSpan={2}>
+                    {isImportedPool ? <ImportedIndicator /> : null}
                     <div className="mb-1 flex font-bold">
                         <OracleDetailsBadgeContainer>
                             <div className="mr-2 text-lg">{pool.leverage}</div>

--- a/archetypes/Pools/PoolsTable/index.tsx
+++ b/archetypes/Pools/PoolsTable/index.tsx
@@ -571,8 +571,8 @@ const TokenRows: React.FC<
     pastUpkeepTokenInfo,
     poolTicker,
 }) => {
-    const getImported = useStore(selectImportedPools);
-    const isImportedPool = useMemo(() => getImported.some((v) => v.address === poolAddress), [poolAddress]);
+    const importedPools = useStore(selectImportedPools);
+    const isImportedPool = useMemo(() => importedPools.some((v) => v.address === poolAddress), [poolAddress]);
 
     const styles = side === SideEnum.long ? longStyles : shortStyles;
 

--- a/components/General/TWTable/index.tsx
+++ b/components/General/TWTable/index.tsx
@@ -78,18 +78,25 @@ TableHeaderCell.defaultProps = {
     twAlign: 'top',
 };
 
-export const TableRow = styled.tr<{ lined?: boolean; isImported?: boolean }>`
-    position: relative;
-    & > td:first-of-type:before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 5px;
-        height: 100%;
-        background-color: ${({ isImported }) => (isImported ? '#FFC700' : 'transparent')};
+export const ImportedIndicator = styled.div<{ isImported?: boolean }>`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: max-content;
+    margin-bottom: 6px;
+    font-family: 'Source Sans Pro', sans-serif;
+    font-weight: 700;
+    border-radius: 3px;
+    padding: 1px 5px;
+    background-color: #ffc700;
+    color: black;
+    font-size: 10px;
+    &:before {
+        content: 'IMPORTED';
     }
+`;
 
+export const TableRow = styled.tr<{ lined?: boolean; isImported?: boolean }>`
     background: ${({ theme, isImported }) => {
         switch (true) {
             case theme.theme === Theme.Dark && isImported:

--- a/components/General/TWTable/index.tsx
+++ b/components/General/TWTable/index.tsx
@@ -78,7 +78,29 @@ TableHeaderCell.defaultProps = {
     twAlign: 'top',
 };
 
-export const TableRow = styled.tr<{ lined?: boolean }>`
+export const TableRow = styled.tr<{ lined?: boolean; isImported?: boolean }>`
+    position: relative;
+    & > td:first-of-type:before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 5px;
+        height: 100%;
+        background-color: ${({ isImported }) => (isImported ? '#FFC700' : 'transparent')};
+    }
+
+    background: ${({ theme, isImported }) => {
+        switch (true) {
+            case theme.theme === Theme.Dark && isImported:
+                return '#111928 !important';
+            case theme.theme === Theme.Light && isImported:
+                return '#ffffff !important';
+            default:
+                return `inherit`;
+        }
+    }};
+
     &:nth-child(even) {
         background: ${({ theme }) => theme.background.primary};
     }

--- a/components/TokenActions/index.tsx
+++ b/components/TokenActions/index.tsx
@@ -22,7 +22,7 @@ export const TokenActions = ({
     otherActions,
     isImported,
 }: {
-    poolAddress: string;
+    poolAddress?: string;
     token: {
         address: string;
         symbol: string;
@@ -47,20 +47,22 @@ export const TokenActions = ({
     const buttonStyles = 'flex cursor-pointer items-center p-2 text-sm hover:bg-theme-button-bg-hover w-full';
 
     const removeImportedPoolFromUi = useCallback((): void => {
-        // Check for imported Pool in localStorage
-        const localStoragePoolAddresses = localStorage.getItem('importedPools');
-        const parsedImportedPools = localStoragePoolAddresses && JSON.parse(localStoragePoolAddresses);
-        const poolIndex = parsedImportedPools?.findIndex((pool: string) => pool === poolAddress);
-        if (poolIndex !== -1) {
-            parsedImportedPools.splice(poolIndex, 1);
-            localStorage.setItem('importedPools', JSON.stringify(parsedImportedPools));
+        if (poolAddress) {
+            // Check for imported Pool in localStorage
+            const localStoragePoolAddresses = localStorage.getItem('importedPools');
+            const parsedImportedPools = localStoragePoolAddresses && JSON.parse(localStoragePoolAddresses);
+            const poolIndex = parsedImportedPools?.findIndex((pool: string) => pool === poolAddress);
+            if (poolIndex !== -1) {
+                parsedImportedPools.splice(poolIndex, 1);
+                localStorage.setItem('importedPools', JSON.stringify(parsedImportedPools));
+            }
+
+            // Remove URL parameters without reloading
+            window.history.pushState({}, document.title, window.location.pathname);
+
+            // Remove imported Pool from store
+            removePool(network as KnownNetwork, poolAddress);
         }
-
-        // Remove URL parameters without reloading
-        window.history.pushState({}, document.title, window.location.pathname);
-
-        // Remove imported Pool from store
-        removePool(network as KnownNetwork, poolAddress);
     }, [poolAddress]);
 
     return (

--- a/components/TokenActions/index.tsx
+++ b/components/TokenActions/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import { PlusOutlined } from '@ant-design/icons';
 import { Popover } from 'react-tiny-popover';
 import shallow from 'zustand/shallow';
@@ -7,6 +7,7 @@ import { Logo, LogoTicker } from '~/components/General';
 import CloseIcon from '~/public/img/general/close.svg';
 import More from '~/public/img/general/more.svg';
 import { useStore } from '~/store/main';
+import { selectRemovePool } from '~/store/PoolsSlice';
 import { selectProvider } from '~/store/Web3Slice';
 import { selectWeb3Info } from '~/store/Web3Slice';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
@@ -14,7 +15,6 @@ import { constructBalancerLink } from '~/utils/balancer';
 import { openBlockExplorer } from '~/utils/blockExplorers';
 import { removeImportedPoolFromUi } from '~/utils/pools';
 import { watchAsset } from '~/utils/rpcMethods';
-import { selectRemovePool } from '~/store/PoolsSlice';
 
 export const TokenActions = ({
     poolAddress,

--- a/components/TokenActions/index.tsx
+++ b/components/TokenActions/index.tsx
@@ -7,13 +7,14 @@ import { Logo, LogoTicker } from '~/components/General';
 import CloseIcon from '~/public/img/general/close.svg';
 import More from '~/public/img/general/more.svg';
 import { useStore } from '~/store/main';
-import { selectRemovePool } from '~/store/PoolsSlice';
 import { selectProvider } from '~/store/Web3Slice';
 import { selectWeb3Info } from '~/store/Web3Slice';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
 import { constructBalancerLink } from '~/utils/balancer';
 import { openBlockExplorer } from '~/utils/blockExplorers';
+import { removeImportedPoolFromUi } from '~/utils/pools';
 import { watchAsset } from '~/utils/rpcMethods';
+import { selectRemovePool } from '~/store/PoolsSlice';
 
 export const TokenActions = ({
     poolAddress,
@@ -45,25 +46,6 @@ export const TokenActions = ({
     const provider = useStore(selectProvider);
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const buttonStyles = 'flex cursor-pointer items-center p-2 text-sm hover:bg-theme-button-bg-hover w-full';
-
-    const removeImportedPoolFromUi = useCallback((): void => {
-        if (poolAddress) {
-            // Check for imported Pool in localStorage
-            const localStoragePoolAddresses = localStorage.getItem('importedPools');
-            const parsedImportedPools = localStoragePoolAddresses && JSON.parse(localStoragePoolAddresses);
-            const poolIndex = parsedImportedPools?.findIndex((pool: string) => pool === poolAddress);
-            if (poolIndex !== -1) {
-                parsedImportedPools.splice(poolIndex, 1);
-                localStorage.setItem('importedPools', JSON.stringify(parsedImportedPools));
-            }
-
-            // Remove URL parameters without reloading
-            window.history.pushState({}, document.title, window.location.pathname);
-
-            // Remove imported Pool from store
-            removePool(network as KnownNetwork, poolAddress);
-        }
-    }, [poolAddress]);
 
     return (
         <Popover
@@ -122,8 +104,13 @@ export const TokenActions = ({
                                   </button>
                               ))
                             : null}
-                        {isImported ? (
-                            <button className={buttonStyles} onClick={removeImportedPoolFromUi}>
+                        {isImported && poolAddress ? (
+                            <button
+                                className={buttonStyles}
+                                onClick={() =>
+                                    removeImportedPoolFromUi(network as KnownNetwork, poolAddress, removePool)
+                                }
+                            >
                                 <CloseIcon className="ml-[1px] mr-2 h-4 w-4" />
                                 Remove Pool from view
                             </button>

--- a/components/TokenActions/index.tsx
+++ b/components/TokenActions/index.tsx
@@ -1,11 +1,13 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { PlusOutlined } from '@ant-design/icons';
 import { Popover } from 'react-tiny-popover';
 import shallow from 'zustand/shallow';
 import { KnownNetwork, NETWORKS } from '@tracer-protocol/pools-js';
 import { Logo, LogoTicker } from '~/components/General';
+import CloseIcon from '~/public/img/general/close.svg';
 import More from '~/public/img/general/more.svg';
 import { useStore } from '~/store/main';
+import { selectRemovePool } from '~/store/PoolsSlice';
 import { selectProvider } from '~/store/Web3Slice';
 import { selectWeb3Info } from '~/store/Web3Slice';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
@@ -14,10 +16,13 @@ import { openBlockExplorer } from '~/utils/blockExplorers';
 import { watchAsset } from '~/utils/rpcMethods';
 
 export const TokenActions = ({
+    poolAddress,
     token,
     arbiscanTarget,
     otherActions,
+    isImported,
 }: {
+    poolAddress: string;
     token: {
         address: string;
         symbol: string;
@@ -33,11 +38,31 @@ export const TokenActions = ({
         logo: LogoTicker;
         text: string;
     }[];
+    isImported?: boolean;
 }): JSX.Element => {
+    const removePool = useStore(selectRemovePool);
     const { network } = useStore(selectWeb3Info, shallow);
     const provider = useStore(selectProvider);
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const buttonStyles = 'flex cursor-pointer items-center p-2 text-sm hover:bg-theme-button-bg-hover w-full';
+
+    const removeImportedPoolFromUi = useCallback((): void => {
+        // Check for imported Pool in localStorage
+        const localStoragePoolAddresses = localStorage.getItem('importedPools');
+        const parsedImportedPools = localStoragePoolAddresses && JSON.parse(localStoragePoolAddresses);
+        const poolIndex = parsedImportedPools?.findIndex((pool: string) => pool === poolAddress);
+        if (poolIndex !== -1) {
+            parsedImportedPools.splice(poolIndex, 1);
+            localStorage.setItem('importedPools', JSON.stringify(parsedImportedPools));
+        }
+
+        // Remove URL parameters without reloading
+        window.history.pushState({}, document.title, window.location.pathname);
+
+        // Remove imported Pool from store
+        removePool(network as KnownNetwork, poolAddress);
+    }, [poolAddress]);
+
     return (
         <Popover
             isOpen={isOpen}
@@ -95,6 +120,12 @@ export const TokenActions = ({
                                   </button>
                               ))
                             : null}
+                        {isImported ? (
+                            <button className={buttonStyles} onClick={removeImportedPoolFromUi}>
+                                <CloseIcon className="ml-[1px] mr-2 h-4 w-4" />
+                                Remove Pool from view
+                            </button>
+                        ) : null}
                     </div>
                 </div>
             }

--- a/components/TokenActions/index.tsx
+++ b/components/TokenActions/index.tsx
@@ -13,7 +13,7 @@ import { selectWeb3Info } from '~/store/Web3Slice';
 import { BlockExplorerAddressType } from '~/types/blockExplorers';
 import { constructBalancerLink } from '~/utils/balancer';
 import { openBlockExplorer } from '~/utils/blockExplorers';
-import { removeImportedPoolFromUi } from '~/utils/pools';
+import { removeImportedPool } from '~/utils/pools';
 import { watchAsset } from '~/utils/rpcMethods';
 
 export const TokenActions = ({
@@ -107,9 +107,7 @@ export const TokenActions = ({
                         {isImported && poolAddress ? (
                             <button
                                 className={buttonStyles}
-                                onClick={() =>
-                                    removeImportedPoolFromUi(network as KnownNetwork, poolAddress, removePool)
-                                }
+                                onClick={() => removeImportedPool(network as KnownNetwork, poolAddress, removePool)}
                             >
                                 <CloseIcon className="ml-[1px] mr-2 h-4 w-4" />
                                 Remove Pool from view

--- a/hooks/useUpdatePoolInstances/index.ts
+++ b/hooks/useUpdatePoolInstances/index.ts
@@ -73,7 +73,14 @@ export const useUpdatePoolInstances = (): void => {
         const poolAddresses = urlParams?.getAll('show');
         // Check if there are any pools to import from localStorage
         const localStoragePoolAddresses = localStorage.getItem('importedPools');
-        const parsedImportedPools = localStoragePoolAddresses && JSON.parse(localStoragePoolAddresses);
+        let parsedImportedPools: any;
+        if (localStoragePoolAddresses) {
+            try {
+                parsedImportedPools = JSON.parse(localStoragePoolAddresses);
+            } catch (err) {
+                parsedImportedPools = [];
+            }
+        }
 
         if (poolLists.length && !hasSetPools.current && !importCheck) {
             if (poolAddresses || localStoragePoolAddresses) {

--- a/hooks/useUpdatePoolInstances/index.ts
+++ b/hooks/useUpdatePoolInstances/index.ts
@@ -93,7 +93,12 @@ export const useUpdatePoolInstances = (): void => {
                     addresses = poolAddresses;
                 }
 
-                console.debug(`Found ${addresses.length} pool${addresses.length > 0 ? 's' : ''} to import:`, addresses);
+                console.debug(
+                    `Found ${addresses.length} pool${
+                        addresses.length > 0 && addresses.length !== 1 ? 's' : ''
+                    } to import:`,
+                    addresses,
+                );
                 addresses.forEach((address) => {
                     handleImport(address);
                 });

--- a/hooks/useUpdatePoolInstances/index.ts
+++ b/hooks/useUpdatePoolInstances/index.ts
@@ -74,13 +74,14 @@ export const useUpdatePoolInstances = (): void => {
         const urlParams = new URLSearchParams(queryString);
         const poolAddresses = urlParams?.getAll('show');
         // Check if there are any pools to import from localStorage
-        const localStoragePoolAddresses = localStorage.getItem('importedPools');
+        const localStoragePoolAddresses = localStorage.getItem(`importedPools${network}`);
         let parsedImportedPools: any;
         if (localStoragePoolAddresses) {
             try {
                 parsedImportedPools = JSON.parse(localStoragePoolAddresses);
             } catch (err) {
                 parsedImportedPools = [];
+                localStorage.setItem(`importedPools${network}`, JSON.stringify([]));
             }
         }
 
@@ -95,8 +96,7 @@ export const useUpdatePoolInstances = (): void => {
                 }
 
                 console.debug(
-                    `Found ${addresses.length} pool${
-                        addresses.length > 0 && addresses.length !== 1 ? 's' : ''
+                    `Found ${addresses.length} pool${addresses.length > 0 && addresses.length !== 1 ? 's' : ''
                     } to import:`,
                     addresses,
                 );

--- a/store/PoolsSlice/index.tsx
+++ b/store/PoolsSlice/index.tsx
@@ -9,9 +9,17 @@ export const createPoolsSlice: StateSlice<IPoolsSlice> = (set, get) => ({
     setPoolLists: (network, lists) => {
         set((state) => void (state.poolLists[network] = lists));
     },
-    importPool: (network, pool) => {
+    importPool: (network, poolAddress) => {
         if (get().poolLists[network]) {
-            set((state) => void state.poolLists[network]?.Imported.pools.push({ address: pool }));
+            set((state) => void state.poolLists[network]?.Imported.pools.push({ address: poolAddress }));
+        }
+    },
+    removePool: (network, poolAddress) => {
+        if (get().poolLists[network]) {
+            const poolIndex = get().poolLists[network]?.Imported.pools.findIndex((v) => v.address === poolAddress);
+            if (typeof poolIndex === 'number' && poolIndex >= 0) {
+                set((state) => void state.poolLists[network]?.Imported.pools.splice(poolIndex, 1));
+            }
         }
     },
     fetchPoolLists: async (network) => {
@@ -31,5 +39,7 @@ export const selectImportedPools: (state: StoreState) => StaticPoolInfo[] = (sta
     state.web3Slice.network ? state.poolsSlice.poolLists[state.web3Slice.network]?.Imported?.pools ?? [] : [];
 export const selectFetchPools: (state: StoreState) => IPoolsSlice['fetchPoolLists'] = (state) =>
     state.poolsSlice.fetchPoolLists;
+export const selectRemovePool: (state: StoreState) => IPoolsSlice['removePool'] = (state) =>
+    state.poolsSlice.removePool;
 export const selectImportPool: (state: StoreState) => IPoolsSlice['importPool'] = (state) =>
     state.poolsSlice.importPool;

--- a/store/PoolsSlice/types.ts
+++ b/store/PoolsSlice/types.ts
@@ -7,5 +7,7 @@ export interface IPoolsSlice {
 
     importPool: (network: KnownNetwork, pool: string) => void;
 
+    removePool: (network: KnownNetwork, pool: string) => void;
+
     fetchPoolLists: (network: KnownNetwork) => Promise<void>;
 }

--- a/utils/pools.ts
+++ b/utils/pools.ts
@@ -244,6 +244,7 @@ export const removeImportedPoolFromUi: (
             removePool(network, poolAddress);
         }
     } catch (err) {
-        console.error('Failed to send Buy action to Segment', err);
+        localStorage.setItem('importedPools', JSON.stringify([]));
+        console.error('Failed to remove custom Pool', err);
     }
 };

--- a/utils/pools.ts
+++ b/utils/pools.ts
@@ -232,12 +232,12 @@ export const removeImportedPoolFromUi: (
     try {
         if (poolAddress) {
             // Check for imported Pool in localStorage
-            const localStoragePoolAddresses = localStorage.getItem('importedPools');
+            const localStoragePoolAddresses = localStorage.getItem(`importedPools${network}`);
             const parsedImportedPools = localStoragePoolAddresses && JSON.parse(localStoragePoolAddresses);
             const poolIndex = parsedImportedPools?.findIndex((pool: string) => pool === poolAddress);
             if (poolIndex !== -1) {
                 parsedImportedPools.splice(poolIndex, 1);
-                localStorage.setItem('importedPools', JSON.stringify(parsedImportedPools));
+                localStorage.setItem(`importedPools${network}`, JSON.stringify(parsedImportedPools));
             }
 
             // Remove URL parameters without reloading
@@ -247,7 +247,7 @@ export const removeImportedPoolFromUi: (
             removePool(network, poolAddress);
         }
     } catch (err) {
-        localStorage.setItem('importedPools', JSON.stringify([]));
+        localStorage.setItem(`importedPools${network}`, JSON.stringify([]));
         console.error('Failed to remove custom Pool', err);
     }
 };

--- a/utils/pools.ts
+++ b/utils/pools.ts
@@ -224,7 +224,7 @@ export const saveImportedPoolsToLocalStorage: (network: KnownNetwork, customPool
     }
 };
 
-export const removeImportedPoolFromUi: (
+export const removeImportedPool: (
     network: KnownNetwork,
     poolAddress: string,
     removePool: (network: KnownNetwork, pool: string) => void,

--- a/utils/pools.ts
+++ b/utils/pools.ts
@@ -2,8 +2,6 @@ import { ethers, BigNumber as EthersBigNumber } from 'ethers';
 import BigNumber from 'bignumber.js';
 import { PoolCommitter__factory, ERC20__factory } from '@tracer-protocol/perpetual-pools-contracts/types';
 import { BalanceTypeEnum, KnownNetwork, Pool } from '@tracer-protocol/pools-js';
-import { useStore } from '~/store/main';
-import { selectRemovePool } from '~/store/PoolsSlice';
 import { AggregateBalances, TradeStats, PoolInfo } from '~/types/pools';
 import { NextPoolState } from '~/types/pools';
 import { formatSeconds } from './converters';


### PR DESCRIPTION
Removes the imported Pool from the UI, store, localStorage and URL parameters.

https://mycelium-mex.atlassian.net/browse/POOL-88

Test with URL to import 2 custom Pools:

/trade/?show=0x09742eDDd5b54C8E2781A5db6B8576C31e882b4e&show=0x16712516f212f19A57566Da2122d7153A0E763b5

Previews

Dark:

![image](https://user-images.githubusercontent.com/19278287/179434723-745c5523-94fe-4d8e-bfd5-92dd65502760.png)

Light:

![image](https://user-images.githubusercontent.com/19278287/179434770-f98f90a2-06ea-4abb-9fff-886e85a6f606.png)

Designs:

https://www.figma.com/file/gA9jQ5B6ZwWjGKBhGUFbKo/2.0-3.0-Pools?node-id=3425%3A210256
