### PR TITLE
Disable Import button on invalid Pool import, show toast error notification on failed load of Pool

### DIFF
--- a/archetypes/Pools/AddAltPoolModal/index.tsx
+++ b/archetypes/Pools/AddAltPoolModal/index.tsx
@@ -67,6 +67,7 @@ export default (({ open, onClose, sortedFilteredTokens }) => {
         } else if (!isValidAddress) {
             setImportMsg(pool.notValid);
         } else {
+            setIsMarketAvailable(true);
             setImportMsg(pool.warning);
         }
     }, [userInput, isValidAddress]);

--- a/archetypes/Pools/AddAltPoolModal/index.tsx
+++ b/archetypes/Pools/AddAltPoolModal/index.tsx
@@ -54,7 +54,11 @@ export default (({ open, onClose, sortedFilteredTokens }) => {
 
     useEffect(() => {
         const isAvailable =
-            ((poolLists?.TracerUnverified.pools || []).filter((v) => v.address === userInput) as StaticPoolInfo[]).length > 0; // Check if Pool exists in list of unverified
+            (
+                (poolLists?.TracerUnverified.pools || []).filter(
+                    (v) => v.address.toLowerCase() === userInput.toLowerCase(),
+                ) as StaticPoolInfo[]
+            ).length > 0; // Check if Pool exists in list of unverified
         if (!isAvailable && isValidAddress) {
             setIsMarketAvailable(false);
             setImportMsg(pool.doesnotexist);

--- a/archetypes/Pools/AddAltPoolModal/index.tsx
+++ b/archetypes/Pools/AddAltPoolModal/index.tsx
@@ -53,7 +53,7 @@ export default (({ open, onClose, sortedFilteredTokens }) => {
 
     useEffect(() => {
         const isAvailable =
-            (poolLists?.TracerUnverified.pools.filter((v) => v.address === userInput) as StaticPoolInfo[]).length > 0; // Check if Pool exists in list of unverified
+            ((poolLists?.TracerUnverified.pools || []).filter((v) => v.address === userInput) as StaticPoolInfo[]).length > 0; // Check if Pool exists in list of unverified
         if (!isAvailable && isValidAddress) {
             setImportMsg(pool.doesnotexist);
         } else if (!userInput) {

--- a/archetypes/Pools/AddAltPoolModal/index.tsx
+++ b/archetypes/Pools/AddAltPoolModal/index.tsx
@@ -22,6 +22,7 @@ export default (({ open, onClose, sortedFilteredTokens }) => {
     const [userInput, setUserInput] = useState<string>('');
     const [importMsg, setImportMsg] = useState<string>('');
     const [isValidAddress, setIsValidAddress] = useState<boolean>(false);
+    const [isMarketAvailable, setIsMarketAvailable] = useState<boolean>(false);
 
     const poolLists = useMemo(() => getPoolsList(network as KnownNetwork), [network]);
 
@@ -55,6 +56,7 @@ export default (({ open, onClose, sortedFilteredTokens }) => {
         const isAvailable =
             ((poolLists?.TracerUnverified.pools || []).filter((v) => v.address === userInput) as StaticPoolInfo[]).length > 0; // Check if Pool exists in list of unverified
         if (!isAvailable && isValidAddress) {
+            setIsMarketAvailable(false);
             setImportMsg(pool.doesnotexist);
         } else if (!userInput) {
             setImportMsg('');
@@ -81,7 +83,7 @@ export default (({ open, onClose, sortedFilteredTokens }) => {
                 <Styles.Message>{importMsg}</Styles.Message>
             </HiddenExpand>
 
-            <Button onClick={handleImport} variant="primary" size="lg" disabled={!isValidAddress}>
+            <Button onClick={handleImport} variant="primary" size="lg" disabled={!isValidAddress || !isMarketAvailable}>
                 Import
             </Button>
         </TWModal>

--- a/archetypes/Pools/AddAltPoolModal/messages.tsx
+++ b/archetypes/Pools/AddAltPoolModal/messages.tsx
@@ -1,5 +1,6 @@
 export const messages = {
     exists: 'This market is already available on the interface.',
+    doesnotexist: 'This market does not exist.',
     notValid: 'Enter a valid pool address.',
     warning:
         'Warning: Markets which do not appear in the curated list have not been assessed for accuracy. They may not perform as expected over any period of time. Use at your own risk.',

--- a/constants/pools.ts
+++ b/constants/pools.ts
@@ -106,6 +106,7 @@ export const DEFAULT_POOLSTATE: PoolInfo = {
 export interface PoolListMap {
     Tracer: {
         verified: string;
+        unverified: string;
         factoryDeployed?: string;
     };
     External: string[];
@@ -120,12 +121,14 @@ export const POOL_LIST_MAP: TokenListMapByNetwork = {
     [NETWORKS.ARBITRUM]: {
         Tracer: {
             verified: `${TRACER_API}/poolsv2/poolList?network=42161&list=verified`,
+            unverified: `${TRACER_API}/poolsv2/poolList?network=42161&list=unverified`,
         },
         External: [],
     },
     [NETWORKS.ARBITRUM_RINKEBY]: {
         Tracer: {
             verified: `${TRACER_API}/poolsv2/poolList?network=421611&list=verified`,
+            unverified: `${TRACER_API}/poolsv2/poolList?network=421611&list=unverified`,
         },
         External: [],
     },

--- a/hooks/useUpdatePoolInstances/index.tsx
+++ b/hooks/useUpdatePoolInstances/index.tsx
@@ -15,12 +15,12 @@ import {
     selectPoolsInitialized,
 } from '~/store/PoolInstancesSlice';
 import { KnownPoolsInitialisationErrors } from '~/store/PoolInstancesSlice/types';
-import { selectImportPool } from '~/store/PoolsSlice';
+import { selectImportPool, selectRemovePool } from '~/store/PoolsSlice';
 import { selectWeb3Info } from '~/store/Web3Slice';
 
 import { V2_SUPPORTED_NETWORKS } from '~/types/networks';
 import { randomIntInRange } from '~/utils/helpers';
-import { saveImportedPoolsToLocalStorage } from '~/utils/pools';
+import { removeImportedPool, saveImportedPoolsToLocalStorage } from '~/utils/pools';
 import { isSupportedNetwork } from '~/utils/supportedNetworks';
 import { fetchPendingCommits } from '~/utils/tracerAPI';
 import { useAllPoolLists } from '../useAllPoolLists';
@@ -44,6 +44,7 @@ export const useUpdatePoolInstances = (): void => {
         updateNextPoolStates,
         updateOracleDetails,
     } = useStore(selectPoolInstanceUpdateActions, shallow);
+    const removePool = useStore(selectRemovePool);
     const importPool = useStore(selectImportPool);
     const { addMultipleCommits } = useStore(selectUserCommitActions, shallow);
     const { provider, account, network } = useStore(selectWeb3Info, shallow);
@@ -99,7 +100,8 @@ export const useUpdatePoolInstances = (): void => {
                 }
 
                 console.debug(
-                    `Found ${addresses.length} pool${addresses.length > 0 && addresses.length !== 1 ? 's' : ''
+                    `Found ${addresses.length} pool${
+                        addresses.length > 0 && addresses.length !== 1 ? 's' : ''
                     } to import:`,
                     addresses,
                 );
@@ -201,6 +203,9 @@ export const useUpdatePoolInstances = (): void => {
                                         autoClose: AUTO_DISMISS,
                                     },
                                 );
+
+                                // Removes imported Pool from localStorage to prevent it loading on refresh
+                                removeImportedPool(network as KnownNetwork, pool.address, removePool);
 
                                 return null;
                             });

--- a/hooks/useUpdatePoolInstances/index.tsx
+++ b/hooks/useUpdatePoolInstances/index.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { ethers } from 'ethers';
 import BigNumber from 'bignumber.js';
 import { isAddress } from 'ethers/lib/utils';
+import { toast } from 'react-toastify';
 import shallow from 'zustand/shallow';
 import { Pool, attemptPromiseRecursively, StaticPoolInfo, KnownNetwork } from '@tracer-protocol/pools-js';
+import { Notification } from '~/components/General/Notification';
 import { useStore } from '~/store/main';
 import { selectUserCommitActions } from '~/store/PendingCommitSlice';
 import {
@@ -24,6 +26,7 @@ import { fetchPendingCommits } from '~/utils/tracerAPI';
 import { useAllPoolLists } from '../useAllPoolLists';
 
 const MAX_RETRY_COUNT = 10;
+const AUTO_DISMISS = 5000; // 5 seconds
 
 /**
  * Wrapper to update all pools information
@@ -173,6 +176,19 @@ export const useUpdatePoolInstances = (): void => {
                             }).catch((error) => {
                                 console.debug(
                                     `Abandoning loading of ${pool.name || pool.address}, retry limit reached: ${error}`,
+                                );
+
+                                toast(
+                                    <Notification title="Error Adding Pool">
+                                        <span className="ml-2 block text-sm">
+                                            Error adding {pool.name ?? pool.address} to interface
+                                        </span>
+                                    </Notification>,
+                                    {
+                                        type: 'error',
+                                        // autoClose: AUTO_DISMISS,
+                                        autoClose: false,
+                                    },
                                 );
 
                                 return null;

--- a/hooks/useUpdatePoolInstances/index.tsx
+++ b/hooks/useUpdatePoolInstances/index.tsx
@@ -186,8 +186,7 @@ export const useUpdatePoolInstances = (): void => {
                                     </Notification>,
                                     {
                                         type: 'error',
-                                        // autoClose: AUTO_DISMISS,
-                                        autoClose: false,
+                                        autoClose: AUTO_DISMISS,
                                     },
                                 );
 

--- a/hooks/useUpdatePoolInstances/index.tsx
+++ b/hooks/useUpdatePoolInstances/index.tsx
@@ -112,8 +112,10 @@ export const useUpdatePoolInstances = (): void => {
             }
             setImportCheck(true);
         } else if (
-            (!poolAddresses || poolAddresses.length === 0) &&
-            (!parsedImportedPools || parsedImportedPools.length === 0)
+            !poolAddresses ||
+            poolAddresses.length === 0 ||
+            !parsedImportedPools ||
+            parsedImportedPools.length === 0
         ) {
             setImportCheck(true);
         }

--- a/store/PoolsSlice/index.tsx
+++ b/store/PoolsSlice/index.tsx
@@ -25,11 +25,16 @@ export const createPoolsSlice: StateSlice<IPoolsSlice> = (set, get) => ({
             set((state) => void (state.poolLists[network] = poolLists));
         }
     },
+    getExistingPoolLists: (network) => {
+        return get().poolLists[network];
+    },
 });
 
 export const selectImportedPools: (state: StoreState) => StaticPoolInfo[] = (state) =>
     state.web3Slice.network ? state.poolsSlice.poolLists[state.web3Slice.network]?.Imported?.pools ?? [] : [];
 export const selectFetchPools: (state: StoreState) => IPoolsSlice['fetchPoolLists'] = (state) =>
     state.poolsSlice.fetchPoolLists;
+export const selectGetPools: (state: StoreState) => IPoolsSlice['getExistingPoolLists'] = (state) =>
+    state.poolsSlice.getExistingPoolLists;
 export const selectImportPool: (state: StoreState) => IPoolsSlice['importPool'] = (state) =>
     state.poolsSlice.importPool;

--- a/store/PoolsSlice/types.ts
+++ b/store/PoolsSlice/types.ts
@@ -8,4 +8,6 @@ export interface IPoolsSlice {
     importPool: (network: KnownNetwork, pool: string) => void;
 
     fetchPoolLists: (network: KnownNetwork) => Promise<void>;
+
+    getExistingPoolLists: (network: KnownNetwork) => PoolLists | undefined;
 }

--- a/types/poolLists.ts
+++ b/types/poolLists.ts
@@ -17,6 +17,7 @@ export interface PoolLists {
     All: PoolList[];
     External: PoolList[];
     Tracer: PoolList;
+    TracerUnverified: PoolList;
     Imported: PoolList;
 }
 
@@ -24,4 +25,5 @@ export interface PoolListUris {
     All: string[];
     External: string[];
     Tracer: string;
+    TracerUnverified: string;
 }

--- a/utils/poolLists.ts
+++ b/utils/poolLists.ts
@@ -18,19 +18,22 @@ const uris = (network: KnownNetwork): PoolListUris => {
     if (!uris) {
         return {
             All: [],
-            Tracer: '',
             External: [],
+            Tracer: '',
+            TracerUnverified: '',
         };
     }
     const { Tracer, External } = uris;
 
     const tracerList = Tracer.verified;
+    const tracerUnverifiedList = Tracer.unverified;
     const All = [tracerList, ...External];
 
     return {
         All,
         External,
         Tracer: tracerList,
+        TracerUnverified: tracerUnverifiedList,
     };
 };
 
@@ -74,6 +77,7 @@ const isStaticPoolInfo = (pool: any): pool is StaticPoolInfo => {
 export const getAllPoolLists = async (network: KnownNetwork): Promise<PoolLists> => {
     const uris_ = uris(network);
     const tracerList: PoolList = await get(uris_.Tracer).catch((e) => e);
+    const tracerUnverifiedList: PoolList = await get(uris_.TracerUnverified).catch((e) => e);
     const externalLists: PoolList[] = await Promise.all(uris_.External.map((uri) => get(uri).catch((e) => e)));
 
     const validTracerList: PoolList =
@@ -81,6 +85,14 @@ export const getAllPoolLists = async (network: KnownNetwork): Promise<PoolLists>
             ? tracerList
             : {
                   name: 'Tracer',
+                  pools: [],
+              };
+
+    const validTracerUnverifiedList: PoolList =
+        (!(tracerUnverifiedList instanceof Error) || !tracerUnverifiedList) && isPoolList(tracerUnverifiedList)
+            ? tracerUnverifiedList
+            : {
+                  name: 'TracerUnverified',
                   pools: [],
               };
 
@@ -99,6 +111,7 @@ export const getAllPoolLists = async (network: KnownNetwork): Promise<PoolLists>
         All: allLists,
         External: validExternalLists,
         Tracer: validTracerList,
+        TracerUnverified: validTracerUnverifiedList,
         Imported: importedList,
     };
 };

--- a/utils/poolLists.ts
+++ b/utils/poolLists.ts
@@ -5,8 +5,8 @@ import { PoolList, PoolLists, PoolListUris } from '~/types/poolLists';
 export const flattenAllPoolLists = (poolLists: PoolLists | undefined): StaticPoolInfo[] =>
     poolLists
         ? poolLists.All.map((pool) => pool.pools)
-              .flat(1)
-              .concat(poolLists.Imported.pools)
+            .flat(1)
+            .concat(poolLists.Imported.pools)
         : [];
 
 /**
@@ -71,6 +71,14 @@ const isStaticPoolInfo = (pool: any): pool is StaticPoolInfo => {
     return pool && pool.address && typeof pool.address === 'string';
 };
 
+const determineValidTracerList = (list: PoolList, name: string): PoolList => {
+    return (!(list instanceof Error) || !list) && isPoolList(list)
+        ? list
+        : {
+            name: name,
+            pools: [],
+        };
+};
 /**
  * Fetch all pool list json and return mapped to URI
  */
@@ -80,21 +88,8 @@ export const getAllPoolLists = async (network: KnownNetwork): Promise<PoolLists>
     const tracerUnverifiedList: PoolList = await get(uris_.TracerUnverified).catch((e) => e);
     const externalLists: PoolList[] = await Promise.all(uris_.External.map((uri) => get(uri).catch((e) => e)));
 
-    const validTracerList: PoolList =
-        (!(tracerList instanceof Error) || !tracerList) && isPoolList(tracerList)
-            ? tracerList
-            : {
-                  name: 'Tracer',
-                  pools: [],
-              };
-
-    const validTracerUnverifiedList: PoolList =
-        (!(tracerUnverifiedList instanceof Error) || !tracerUnverifiedList) && isPoolList(tracerUnverifiedList)
-            ? tracerUnverifiedList
-            : {
-                  name: 'TracerUnverified',
-                  pools: [],
-              };
+    const validTracerList = determineValidTracerList(tracerList, 'Tracer');
+    const validTracerUnverifiedList = determineValidTracerList(tracerUnverifiedList, 'TracerUnverified');
 
     const validExternalLists = externalLists.filter((list) => (!(list instanceof Error) || !list) && isPoolList(list));
     const importedList = {


### PR DESCRIPTION
https://mycelium-mex.atlassian.net/browse/POOL-94

Can be tested by running branch locally, removing the `disabled` attribute from L84 of `AddAltPoolModal.tsx`, and using any address not in the Pools list (e.g. 0x051afD0b39ACF4Cc52c76a479aD802d0B82A8249)

![image](https://user-images.githubusercontent.com/19278287/179687233-39dfa5f7-2b15-421f-b052-0c65487884e7.png)
