### PR TITLE
render token prices to 5 decimal places

### DIFF
--- a/archetypes/BuyTokens/ExchangeButtons.tsx
+++ b/archetypes/BuyTokens/ExchangeButtons.tsx
@@ -95,7 +95,7 @@ export const ExchangeButtons: React.FC<EXButtonsProps> = ({
                 <BuyButtonContainer>
                     <BuyText>
                         Mint <b>{`${expectedAmount.toNumber().toFixed(3)}`}</b> tokens at{' '}
-                        <b>{toApproxCurrency(tokenPrice, 3)}</b> in{' '}
+                        <b>{toApproxCurrency(tokenPrice, 5)}</b> in{' '}
                         <b>
                             <TimeLeft targetTime={receiveIn} />
                         </b>
@@ -129,7 +129,7 @@ export const ExchangeButtons: React.FC<EXButtonsProps> = ({
                         {isValidOnBalancer ? (
                             <>
                                 Buy <b>{expectedBalancerAmount?.toNumber().toFixed(3)}</b> tokens at{' '}
-                                <b>${balancerPrice && parseFloat(balancerPrice.toString()).toFixed(3)}</b> instantly
+                                <b>${balancerPrice && parseFloat(balancerPrice.toString()).toFixed(5)}</b> instantly
                             </>
                         ) : (
                             <>

--- a/archetypes/Exchange/Inputs/AmountInput.tsx
+++ b/archetypes/Exchange/Inputs/AmountInput.tsx
@@ -33,13 +33,13 @@ const Available: React.FC<{
         <>
             {isPoolToken ? (
                 <>
-                    {`${balance.toFixed(3)} `}
-                    {amountBN.gt(0) ? <span className="opacity-80">{`>>> ${balanceAfter.toFixed(3)}`}</span> : null}
+                    {`${balance.toFixed(5)} `}
+                    {amountBN.gt(0) ? <span className="opacity-80">{`>>> ${balanceAfter.toFixed(5)}`}</span> : null}
                     {` tokens available`}
                     {otherBalance && otherBalance.gt(0) ? (
                         <>
                             <br />
-                            <span className="opacity-80">{`${otherBalance.toFixed(3)} in ${tokenSource()}`}</span>
+                            <span className="opacity-80">{`${otherBalance.toFixed(5)} in ${tokenSource()}`}</span>
                         </>
                     ) : null}
                 </>

--- a/archetypes/Exchange/Inputs/index.tsx
+++ b/archetypes/Exchange/Inputs/index.tsx
@@ -31,7 +31,7 @@ export const isInvalidAmount: (
                 ? `Not enough funds! ${
                       (commitAction as CommitActionEnum) === CommitActionEnum.mint
                           ? toApproxCurrency(balance)
-                          : `${balance.toFixed(3)} tokens`
+                          : `${balance.toFixed(5)} tokens`
                   } available`
                 : undefined,
             isInvalid: true,
@@ -129,7 +129,7 @@ export default (({ pool, userBalances, swapState, swapDispatch }) => {
                     }}
                 />
                 <Styles.Subtext showContent={!!pool.address}>
-                    Expected Price: {toApproxCurrency(tokenPrice, 3)}
+                    Expected Price: {toApproxCurrency(tokenPrice, 5)}
                 </Styles.Subtext>
             </Styles.Wrapper>
             <Styles.Container>

--- a/archetypes/Exchange/Summary/Sections.tsx
+++ b/archetypes/Exchange/Summary/Sections.tsx
@@ -14,7 +14,7 @@ export const ExpectedTokenPrice: React.FC<{
 }> = ({ tokenPrice, settlementTokenSymbol }) => (
     <div>
         <Styles.Transparent>
-            {` at ${toApproxCurrency(tokenPrice ?? 1, 3)} ${settlementTokenSymbol}/token`}
+            {` at ${toApproxCurrency(tokenPrice ?? 1, 5)} ${settlementTokenSymbol}/token`}
         </Styles.Transparent>
     </div>
 );
@@ -64,14 +64,14 @@ export const ExpectedTokensMinted: React.FC<
     <>
         <Section label="Expected tokens minted" className="header">
             <Styles.SumText>
-                {expectedTokensMinted > 0 ? expectedTokensMinted.toFixed(3) : ''} {tokenSymbol}
+                {expectedTokensMinted > 0 ? expectedTokensMinted.toFixed(5) : ''} {tokenSymbol}
             </Styles.SumText>
         </Section>
         {showTransactionDetails && (
             <Styles.SectionDetails>
                 <Section label="Expected amount" showSectionDetails>
                     <Styles.Transparent>
-                        <span>{`${expectedTokensMinted.toFixed(3)}`} tokens</span>
+                        <span>{`${expectedTokensMinted.toFixed(5)}`} tokens</span>
                     </Styles.Transparent>
                 </Section>
                 <Section label="Expected price" showSectionDetails>
@@ -134,14 +134,14 @@ export const ExpectedExposure: React.FC<
         <>
             <Section label={label} className="header">
                 <Styles.SumText className={isLong ? 'text-up-green' : 'text-down-red'}>
-                    {expectedExposure.toFixed(3)} {baseAsset}
+                    {expectedExposure.toFixed(5)} {baseAsset}
                 </Styles.SumText>
             </Section>
             {showTransactionDetails && (
                 <Styles.SectionDetails>
                     <Section label={`Market value at ${toApproxCurrency(oraclePrice)} USD`} showSectionDetails>
                         <Styles.Transparent>
-                            {commitAmount.toFixed(3)} {baseAsset}
+                            {commitAmount.toFixed(5)} {baseAsset}
                         </Styles.Transparent>
                     </Section>
                     <Section label="Leverage" showSectionDetails>
@@ -166,7 +166,7 @@ export const ExpectedBurnFees: React.FC<
     return (
         <>
             <Section label="Expected fees" className="header">
-                <Styles.SumText>{`${toApproxCurrency(totalFee, 3)} USD`}</Styles.SumText>
+                <Styles.SumText>{`${toApproxCurrency(totalFee, 5)} USD`}</Styles.SumText>
             </Section>
             {showTransactionDetails && (
                 <Styles.SectionDetails>
@@ -199,7 +199,7 @@ export const ExpectedFlipFees: React.FC<
     return (
         <>
             <Section label="Expected fees" className="header">
-                <Styles.SumText>{`${toApproxCurrency(totalFee, 3)} USD`}</Styles.SumText>
+                <Styles.SumText>{`${toApproxCurrency(totalFee, 5)} USD`}</Styles.SumText>
             </Section>
             {showTransactionDetails && (
                 <Styles.SectionDetails>

--- a/archetypes/Exchange/TokenSelect/TokenSelect.tsx
+++ b/archetypes/Exchange/TokenSelect/TokenSelect.tsx
@@ -85,7 +85,7 @@ const TokenSelect: React.FC<{
                                     <Styles.TokenSelectCell hasBalance={token.escrowBalance.toNumber() > 0}>
                                         {token.escrowBalance.toNumber() > 0 ? (
                                             <>
-                                                {token.escrowBalance?.toFixed(3)}
+                                                {token.escrowBalance?.toFixed(5)}
                                                 <span>Tokens</span>
                                             </>
                                         ) : (
@@ -95,7 +95,7 @@ const TokenSelect: React.FC<{
                                     <Styles.TokenSelectCell hasBalance={token.balance.toNumber() > 0}>
                                         {token.balance.toNumber() > 0 ? (
                                             <>
-                                                {token.balance.toNumber().toFixed(3)}
+                                                {token.balance.toNumber().toFixed(5)}
                                                 <span>Tokens</span>
                                             </>
                                         ) : (

--- a/archetypes/Pools/PoolsTable/index.tsx
+++ b/archetypes/Pools/PoolsTable/index.tsx
@@ -604,11 +604,11 @@ const TokenRows: React.FC<
             <TableRowCell size={'sm'}>{leverage}</TableRowCell>
             <TableRowCell size={'sm'}>
                 {showNextRebalance ? (
-                    toApproxCurrency(tokenInfo.nextTCRPrice, 3)
+                    toApproxCurrency(tokenInfo.nextTCRPrice, 5)
                 ) : (
                     <>
                         <div className="flex">
-                            <div className="mr-1">{toApproxCurrency(pastUpkeepTokenInfo.tokenPrice, 3)}</div>
+                            <div className="mr-1">{toApproxCurrency(pastUpkeepTokenInfo.tokenPrice, 5)}</div>
                             <UpOrDownWithTooltip
                                 oldValue={antecedentUpkeepTokenInfo.tokenPrice}
                                 newValue={pastUpkeepTokenInfo.tokenPrice}
@@ -626,7 +626,7 @@ const TokenRows: React.FC<
                 <TableRowCell size={'sm'}>
                     {tokenInfo.balancerPrice ? (
                         <div className="flex items-center">
-                            {toApproxCurrency(tokenInfo.balancerPrice, 3)}
+                            {toApproxCurrency(tokenInfo.balancerPrice, 5)}
                             <TradeOnBalancerTip>
                                 <LinkIcon
                                     className="ml-2 inline-block"
@@ -650,13 +650,13 @@ const TokenRows: React.FC<
                 <TableRowCell size={'sm'}>
                     <div className="flex">
                         <Logo size="xs" ticker={tokenSymbolToLogoTicker(tokenInfo.symbol)} className="my-auto mr-1" />
-                        {tokenInfo.userHoldings === 0 ? '-' : tokenInfo.userHoldings.toFixed(3)}
+                        {tokenInfo.userHoldings === 0 ? '-' : tokenInfo.userHoldings.toFixed(5)}
                     </div>
                     <div className="flex">
                         <Logo size="xs" ticker={settlementTokenSymbol as LogoTicker} className="my-auto mr-1" />
                         {tokenInfo.userHoldings === 0
                             ? '-'
-                            : toApproxCurrency(tokenInfo.userHoldings * tokenInfo.nextTCRPrice, 3)}
+                            : toApproxCurrency(tokenInfo.userHoldings * tokenInfo.nextTCRPrice, 5)}
                     </div>
                 </TableRowCell>
             ) : null}
@@ -760,7 +760,7 @@ const UpOrDownWithTooltip: React.FC<{
                     : calcPercentageDifference(newValue, oldValue),
             [deltaDenotation, oldValue, newValue],
         );
-        const approxValue = Math.abs(parseFloat(value.toFixed(3)));
+        const approxValue = Math.abs(parseFloat(value.toFixed(5)));
         return (
             <UpOrDownWithTooltipTip
                 metric={tooltipMetric}

--- a/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
+++ b/archetypes/Portfolio/ClaimedTokensTable/ClaimedTokenRow.tsx
@@ -54,7 +54,7 @@ export const ClaimedTokenRow: React.FC<ClaimedTokenRowProps & ClaimedRowActions>
                 />
             </OverviewTableRowCell>
             <OverviewTableRowCell>
-                <div>{`${leveragedNotionalValue.toFixed(3)} ${settlementTokenSymbol}`}</div>
+                <div>{`${leveragedNotionalValue.toFixed(5)} ${settlementTokenSymbol}`}</div>
             </OverviewTableRowCell>
             <ActionsCell>
                 <PortfolioStakeTooltip>

--- a/archetypes/Portfolio/Market.tsx
+++ b/archetypes/Portfolio/Market.tsx
@@ -76,13 +76,13 @@ export const TokenPrice = ({
 }): JSX.Element => {
     const simplifiedIn = getSimplifiedTokenName(tokenInSymbol);
     const simplifiedOut = getSimplifiedTokenName(tokenOutSymbol);
-    return <div>{`${price.toFixed(3)} ${simplifiedIn}/${simplifiedOut}`}</div>;
+    return <div>{`${price.toFixed(5)} ${simplifiedIn}/${simplifiedOut}`}</div>;
 };
 
 export const Amount = ({ tokenSymbol, amount }: { tokenSymbol: string; amount: BigNumber }): JSX.Element => (
     <MarketContainer>
         <MarketLogo size="lg" ticker={tokenSymbolToLogoTicker(tokenSymbol)} />
-        <div>{amount.toFixed(3)}</div>
+        <div>{amount.toFixed(5)}</div>
     </MarketContainer>
 );
 

--- a/archetypes/Portfolio/Tokens.tsx
+++ b/archetypes/Portfolio/Tokens.tsx
@@ -30,9 +30,9 @@ export const TokensNotional = ({
     settlementTokenSymbol: string;
 }): JSX.Element => (
     <>
-        <div>{`${amount.times(price).toFixed(3)} ${settlementTokenSymbol}`}</div>
+        <div>{`${amount.times(price).toFixed(5)} ${settlementTokenSymbol}`}</div>
         <InnerCellSubText>
-            {`${amount.toFixed(3)} tokens at ${price.toFixed(2)} ${settlementTokenSymbol}/token`}
+            {`${amount.toFixed(5)} tokens at ${price.toFixed(5)} ${settlementTokenSymbol}/token`}
         </InnerCellSubText>
     </>
 );


### PR DESCRIPTION
render token prices/amounts to 5 decimal places, this solves the following problems:

- the long side 10x market token price is $0.00040 which shows as $0.000 with 3 decimals (current value)
- notional bitcoin exposure for small mints can show as 0.000