### PR TITLE
add geoblock popup

### DIFF
--- a/components/General/Layout/index.tsx
+++ b/components/General/Layout/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import Footer from '~/components/Footer';
 import UnsupportedNetworkPopup from '~/components/General/UnsupportedNetworkPopup';
 import { UserSnap } from '~/components/General/Usersnap';
+import { GeoblockModal } from '~/components/GeoblockModal';
 import NavBar from '~/components/Nav/Navbar';
 import OnboardTradeModal from '~/components/OnboardModal/Trade';
 import { AnalyticsProvider } from '~/context/AnalyticsContext';
@@ -17,6 +18,7 @@ export const Layout: React.FC = ({ children }) => {
             <NavBar />
             <AnalyticsProvider>{children}</AnalyticsProvider>
             <UnsupportedNetworkPopup />
+            <GeoblockModal />
             <OnboardTradeModal
                 onboardStep={onboardStep}
                 setOnboardStep={setOnboardStep}

--- a/components/GeoblockModal/GeoblockModal.tsx
+++ b/components/GeoblockModal/GeoblockModal.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import Button from '~/components/General/Button';
+import Divider from '~/components/General/Divider';
+import { TWModal } from '~/components/General/TWModal';
+import * as Styled from './styles';
+
+const key = 'hasSeenGeoblockModal';
+
+const GeoblockModal: React.FC = () => {
+    const [hasSeen, setHasSeen] = useState(true);
+
+    useEffect(() => {
+        const _hasSeen = localStorage.getItem(key);
+        setHasSeen(_hasSeen === 'true');
+    }, []);
+
+    const modalSeen = (confirmed: boolean) => {
+        if (confirmed) {
+            localStorage.setItem(key, 'true');
+        }
+        setHasSeen(true);
+    };
+
+    const GeoblockContent = () => {
+        return (
+            <>
+                <div className="my-5 text-center text-2xl">Upcoming Changes</div>
+                <Divider className="mb-8" />
+                <div className="mb-8">
+                    <strong>
+                        Notice to Australian users of Perpetual Swaps, Perpetual Pools, MYC Staking, and the TCR to MYC
+                        Token Migration portals.
+                    </strong>
+                    <br />
+                    <br />
+                    Please note that from 11:59 pm AEST on 16 December 2022, Australian users will be geo-blocked from
+                    accessing these subdomains. It is recommended that Australian users close out any involvement they
+                    have with these four products before this time.
+                </div>
+                <div className="dark:bg-theme-button-gradient-bg flex flex-col-reverse sm:flex-row">
+                    <Button className="gradient-button" variant="primary-light" onClick={() => modalSeen(true)}>
+                        I understand
+                    </Button>
+                </div>
+            </>
+        );
+    };
+
+    return (
+        <TWModal open={!hasSeen} onClose={() => modalSeen(false)}>
+            <Styled.Close onClick={() => modalSeen(false)} />
+            <Styled.GeoblockContent className="onboard">{GeoblockContent()}</Styled.GeoblockContent>
+        </TWModal>
+    );
+};
+
+export default GeoblockModal;

--- a/components/GeoblockModal/index.ts
+++ b/components/GeoblockModal/index.ts
@@ -1,0 +1,1 @@
+export { default as GeoblockModal } from './GeoblockModal';

--- a/components/GeoblockModal/styles.tsx
+++ b/components/GeoblockModal/styles.tsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+import CloseSVG from '/public/img/general/close.svg';
+
+export const GeoblockContent = styled.div`
+    a {
+        text-decoration: underline;
+        cursor: pointer;
+    }
+`;
+
+export const Close = styled(CloseSVG)`
+    width: 1rem;
+    height: 1rem;
+    margin-left: auto;
+    cursor: pointer;
+    position: absolute;
+    right: 35px;
+    top: 46px;
+`;


### PR DESCRIPTION
Adds a popup with details of upcoming geoblocking changes

- it will only flag local storage (to prevent it from showing) if the user clicks the `I understand` button.Closing the modal via outside click or the close button will not mark the modal as seen 